### PR TITLE
Extend the unit tests

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+src-gen/
+components/
+*.rossystem
+!robotino.rossystem

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: de.fraunhofer.ipa.ros.xtext,
  de.fraunhofer.ipa.ros,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ de.fraunhofer.ipa.roscode.generator
 Import-Package: org.apache.log4j,
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/build.properties
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/build.properties
@@ -1,6 +1,7 @@
 source.. = src/,\
            src-gen/,\
-           xtend-gen/
+           xtend-gen/,\
+           resources/
 bin.includes = .,\
                META-INF/
 bin.excludes = **/*.xtend

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/ros2generator/cob_sick_s300.cpp
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/ros2generator/cob_sick_s300.cpp
@@ -6,9 +6,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/cmdline_parser.h"
-#include <sensor_msgs/msg/LaserScan.hpp>
-#include <std_msgs/msg/Bool.hpp>
-#include <diagnostic_msgs/msg/DiagnosticArray.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+
+using namespace std::chrono_literals;
+using std::placeholders::_1;
+using std::placeholders::_2;
+using std::placeholders::_3;
 
 void print_usage()
 {
@@ -16,63 +21,48 @@ void print_usage()
   printf("..... \n");
   printf("..... \n");
   printf("..... \n");
-
 }
 
   class cob_sick_s300 : public rclcpp::Node {
-  	public:
-	  explicit cob_sick_s300(const std::string & scan scan_standby /diagnostics ) : Node("cob_sick_s300")
-	  auto publish_message = [this]() -> void {
-    	msg_scan_ = std::make_unique<sensor_msgs::msg::LaserScan>();
-    	scan_->publish(std::move(msg_scan_));
-    	msg_scan_standby_ = std::make_unique<std_msgs::msg::Bool>();
-    	scan_standby_->publish(std::move(msg_scan_standby_));
-    	msg_/diagnostics_ = std::make_unique<diagnostic_msgs::msg::DiagnosticArray>();
-    	/diagnostics_->publish(std::move(msg_/diagnostics_));
-	  };
+    public:
+      cob_sick_s300() : Node("cob_sick_s300") {
+        scan_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan",10);
+        scan_standby_ = this->create_publisher<std_msgs::msg::Bool>("scan_standby",10);
+        diagnostics_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics",10);
 
-	  rclcpp::QoS qos(rclcpp::KeepLast(7));
-scan_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan, qos);
-scan_standby_ = this->create_publisher<std_msgs::msg::Bool>(scan_standby, qos);
-/diagnostics_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(/diagnostics, qos);
-}
+        timer_ = this->create_wall_timer(500ms, std::bind(&cob_sick_s300::timer_callback, this));
 
-private:
-  size_t count_ = 1;
-  std::unique_ptr<sensor_msgs::msg::LaserScan> msg_scan_;
-  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_;
-  std::unique_ptr<std_msgs::msg::Bool> msg_scan_standby_;
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr scan_standby_;
-  std::unique_ptr<diagnostic_msgs::msg::DiagnosticArray> msg_/diagnostics_;
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr /diagnostics_;
-  rclcpp::TimerBase::SharedPtr timer_;
+      }
+
+    private:
+      rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_;
+      rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr scan_standby_;
+      rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_;
+      // Timer Callback
+      void timer_callback(){
+        auto scan_msg = sensor_msgs::msg::LaserScan();
+        //scan_msg = ...
+        scan_->publish(scan_msg);
+        RCLCPP_INFO(this->get_logger(), "scan publisher active");
+        auto scan_standby_msg = std_msgs::msg::Bool();
+        //scan_standby_msg = ...
+        scan_standby_->publish(scan_standby_msg);
+        RCLCPP_INFO(this->get_logger(), "scan_standby publisher active");
+        auto diagnostics_msg = diagnostic_msgs::msg::DiagnosticArray();
+        //diagnostics_msg = ...
+        diagnostics_->publish(diagnostics_msg);
+        RCLCPP_INFO(this->get_logger(), "/diagnostics publisher active");
+      }
+      rclcpp::TimerBase::SharedPtr timer_;
+
+      
 };
 
 int main(int argc, char * argv[])
 {
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-
-  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
-    print_usage();
-    return 0;
-  }
-
   rclcpp::init(argc, argv);
-  auto scan = std::string("scan");
-  auto scan_standby = std::string("scan_standby");
-  auto /diagnostics = std::string("/diagnostics");
-  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-t");
-  if (nullptr != cli_option) {
-  scan = std::string(cli_option);
-  scan_standby = std::string(cli_option);
-  /diagnostics = std::string(cli_option);
-  }
-   auto node = std::make_shared<cob_sick_s300>(scan)
-   auto node = std::make_shared<cob_sick_s300>(scan_standby)
-   auto node = std::make_shared<cob_sick_s300>(/diagnostics)
-
-  rclcpp::spin(cob_sick_s300);
-
+  rclcpp::spin(std::make_shared<cob_sick_s300>());
   rclcpp::shutdown();
   return 0;
 }
+

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/ros2generator/cob_sick_s300.cpp
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/ros2generator/cob_sick_s300.cpp
@@ -1,0 +1,78 @@
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+#include <sensor_msgs/msg/LaserScan.hpp>
+#include <std_msgs/msg/Bool.hpp>
+#include <diagnostic_msgs/msg/DiagnosticArray.hpp>
+
+void print_usage()
+{
+  printf("Usage for cob_sick_s300 app:\n");
+  printf("..... \n");
+  printf("..... \n");
+  printf("..... \n");
+
+}
+
+  class cob_sick_s300 : public rclcpp::Node {
+  	public:
+	  explicit cob_sick_s300(const std::string & scan scan_standby /diagnostics ) : Node("cob_sick_s300")
+	  auto publish_message = [this]() -> void {
+    	msg_scan_ = std::make_unique<sensor_msgs::msg::LaserScan>();
+    	scan_->publish(std::move(msg_scan_));
+    	msg_scan_standby_ = std::make_unique<std_msgs::msg::Bool>();
+    	scan_standby_->publish(std::move(msg_scan_standby_));
+    	msg_/diagnostics_ = std::make_unique<diagnostic_msgs::msg::DiagnosticArray>();
+    	/diagnostics_->publish(std::move(msg_/diagnostics_));
+	  };
+
+	  rclcpp::QoS qos(rclcpp::KeepLast(7));
+scan_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan, qos);
+scan_standby_ = this->create_publisher<std_msgs::msg::Bool>(scan_standby, qos);
+/diagnostics_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(/diagnostics, qos);
+}
+
+private:
+  size_t count_ = 1;
+  std::unique_ptr<sensor_msgs::msg::LaserScan> msg_scan_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_;
+  std::unique_ptr<std_msgs::msg::Bool> msg_scan_standby_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr scan_standby_;
+  std::unique_ptr<diagnostic_msgs::msg::DiagnosticArray> msg_/diagnostics_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr /diagnostics_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char * argv[])
+{
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
+    print_usage();
+    return 0;
+  }
+
+  rclcpp::init(argc, argv);
+  auto scan = std::string("scan");
+  auto scan_standby = std::string("scan_standby");
+  auto /diagnostics = std::string("/diagnostics");
+  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-t");
+  if (nullptr != cli_option) {
+  scan = std::string(cli_option);
+  scan_standby = std::string(cli_option);
+  /diagnostics = std::string(cli_option);
+  }
+   auto node = std::make_shared<cob_sick_s300>(scan)
+   auto node = std::make_shared<cob_sick_s300>(scan_standby)
+   auto node = std::make_shared<cob_sick_s300>(/diagnostics)
+
+  rclcpp::spin(cob_sick_s300);
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/rosgenerator/cob_sick_s300.cpp
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/resources/rosgenerator/cob_sick_s300.cpp
@@ -1,0 +1,20 @@
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+#include <std_msgs/Bool.h>
+#include <diagnostic_msgs/DiagnosticArray.h>
+
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "cob_sick_s300");
+  ros::NodeHandle n;
+  
+  ros::Publisher scan_pub = n.advertise<sensor_msgs::LaserScan>("scan", 10);
+  ros::Publisher scan_standby_pub = n.advertise<std_msgs::Bool>("scan_standby", 10);
+  ros::Publisher /diagnostics_pub = n.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 10);
+
+  ros::spin();
+
+  return 0;
+}

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
@@ -13,15 +13,16 @@ import org.eclipse.xtext.generator.InMemoryFileSystemAccess
 import org.eclipse.xtext.generator.GeneratorContext
 import de.fraunhofer.ipa.roscode.generator.CustomOutputProvider
 
-
 import de.fraunhofer.ipa.roscode.generator.Ros2CodeGenerator
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @RunWith(XtextRunner)
 @InjectWith(RosInjectorProvider)
 class RosGeneratorTest {
 	@Inject
 	RosCodeGenerator rosGenerator
-	
+
 	@Inject
 	Ros2CodeGenerator ros2Generator
 
@@ -31,8 +32,11 @@ class RosGeneratorTest {
 	@Inject
 	RosTestingUtils rosTestingUtils
 
+	String RESOURCES_BASE_DIR = 'resources'
+
 	@Test
 	def void testGeneratedRosCode() {
+
 		val resourceSet = rosTestingUtils.getMessagesResourceSet
 		val model = parseHelper.parse('''
 			PackageSet { package { 
@@ -50,32 +54,15 @@ class RosGeneratorTest {
 		rosGenerator.doGenerate(model.eResource, fsa, new GeneratorContext)
 
 		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp"))
-		Assert.assertEquals('''#include <ros/ros.h>
-#include <sensor_msgs/LaserScan.h>
-#include <std_msgs/Bool.h>
-#include <diagnostic_msgs/DiagnosticArray.h>
-
-
-
-int main(int argc, char **argv)
-{
-  ros::init(argc, argv, "cob_sick_s300");
-  ros::NodeHandle n;
-  
-  ros::Publisher scan_pub = n.advertise<sensor_msgs::LaserScan>("scan", 10);
-  ros::Publisher scan_standby_pub = n.advertise<std_msgs::Bool>("scan_standby", 10);
-  ros::Publisher /diagnostics_pub = n.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 10);
-
-  ros::spin();
-
-  return 0;
-}'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
+		Assert.assertEquals(
+			new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR, 'rosgenerator', 'cob_sick_s300.cpp'))).trim,
+			fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
 	}
-	
+
 	@Test
 	def void testGeneratedRos2Code() {
 		val resourceSet = rosTestingUtils.getMessagesResourceSet
-		
+
 		val model = parseHelper.parse('''
 			PackageSet { package { 
 			  CatkinPackage cob_sick_s300 { artifact {
@@ -87,90 +74,13 @@ int main(int argc, char **argv)
 			          Publisher { name '/diagnostics' message 'diagnostic_msgs.DiagnosticArray'}}
 			}}}}}}
 		''', resourceSet)
-		
+
 		val fsa = new InMemoryFileSystemAccess
 		ros2Generator.doGenerate(model.eResource, fsa, new GeneratorContext)
 		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp"))
-		Assert.assertEquals('''#include <chrono>
-#include <cstdio>
-#include <memory>
-#include <string>
-#include <utility>
-
-#include "rclcpp/rclcpp.hpp"
-#include "rcutils/cmdline_parser.h"
-#include <sensor_msgs/msg/LaserScan.hpp>
-#include <std_msgs/msg/Bool.hpp>
-#include <diagnostic_msgs/msg/DiagnosticArray.hpp>
-
-void print_usage()
-{
-  printf("Usage for cob_sick_s300 app:\n");
-  printf("..... \n");
-  printf("..... \n");
-  printf("..... \n");
-
-}
-
-  class cob_sick_s300 : public rclcpp::Node {
-  	public:
-	  explicit cob_sick_s300(const std::string & scan scan_standby /diagnostics ) : Node("cob_sick_s300")
-	  auto publish_message = [this]() -> void {
-    	msg_scan_ = std::make_unique<sensor_msgs::msg::LaserScan>();
-    	scan_->publish(std::move(msg_scan_));
-    	msg_scan_standby_ = std::make_unique<std_msgs::msg::Bool>();
-    	scan_standby_->publish(std::move(msg_scan_standby_));
-    	msg_/diagnostics_ = std::make_unique<diagnostic_msgs::msg::DiagnosticArray>();
-    	/diagnostics_->publish(std::move(msg_/diagnostics_));
-	  };
-
-	  rclcpp::QoS qos(rclcpp::KeepLast(7));
-scan_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan, qos);
-scan_standby_ = this->create_publisher<std_msgs::msg::Bool>(scan_standby, qos);
-/diagnostics_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(/diagnostics, qos);
-}
-
-private:
-  size_t count_ = 1;
-  std::unique_ptr<sensor_msgs::msg::LaserScan> msg_scan_;
-  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_;
-  std::unique_ptr<std_msgs::msg::Bool> msg_scan_standby_;
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr scan_standby_;
-  std::unique_ptr<diagnostic_msgs::msg::DiagnosticArray> msg_/diagnostics_;
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr /diagnostics_;
-  rclcpp::TimerBase::SharedPtr timer_;
-};
-
-int main(int argc, char * argv[])
-{
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-
-  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
-    print_usage();
-    return 0;
-  }
-
-  rclcpp::init(argc, argv);
-  auto scan = std::string("scan");
-  auto scan_standby = std::string("scan_standby");
-  auto /diagnostics = std::string("/diagnostics");
-  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-t");
-  if (nullptr != cli_option) {
-  scan = std::string(cli_option);
-  scan_standby = std::string(cli_option);
-  /diagnostics = std::string(cli_option);
-  }
-   auto node = std::make_shared<cob_sick_s300>(scan)
-   auto node = std::make_shared<cob_sick_s300>(scan_standby)
-   auto node = std::make_shared<cob_sick_s300>(/diagnostics)
-
-  rclcpp::spin(cob_sick_s300);
-
-  rclcpp::shutdown();
-  return 0;
-}'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
+		Assert.assertEquals(
+			new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR, 'ros2generator', 'cob_sick_s300.cpp'))).trim,
+			fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
 	}
-	
-	
 
 }

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
@@ -12,11 +12,8 @@ import ros.PackageSet
 import org.eclipse.xtext.generator.InMemoryFileSystemAccess
 import org.eclipse.xtext.generator.GeneratorContext
 import de.fraunhofer.ipa.roscode.generator.CustomOutputProvider
-import com.google.inject.Provider
-import org.eclipse.xtext.resource.XtextResourceSet
-import org.eclipse.emf.common.util.URI
-import org.eclipse.xtext.util.StringInputStream
-import org.eclipse.emf.ecore.resource.ResourceSet
+
+
 import de.fraunhofer.ipa.roscode.generator.Ros2CodeGenerator
 
 @RunWith(XtextRunner)
@@ -32,11 +29,11 @@ class RosGeneratorTest {
 	ParseHelper<PackageSet> parseHelper
 
 	@Inject
-	Provider<XtextResourceSet> resourceSetProvider
+	RosTestingUtils rosTestingUtils
 
 	@Test
 	def void testGeneratedRosCode() {
-		val resourceSet = getMessagesResourceSet
+		val resourceSet = rosTestingUtils.getMessagesResourceSet
 		val model = parseHelper.parse('''
 			PackageSet { package { 
 			  CatkinPackage cob_sick_s300 { artifact {
@@ -77,7 +74,7 @@ int main(int argc, char **argv)
 	
 	@Test
 	def void testGeneratedRos2Code() {
-		val resourceSet = getMessagesResourceSet
+		val resourceSet = rosTestingUtils.getMessagesResourceSet
 		
 		val model = parseHelper.parse('''
 			PackageSet { package { 
@@ -174,24 +171,6 @@ int main(int argc, char * argv[])
 }'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
 	}
 	
-	def ResourceSet getMessagesResourceSet() {
-		val resourceSet = resourceSetProvider.get
-
-		val messages = resourceSet.createResource(URI.createURI("common_msgs.ros"))
-		messages.load(new StringInputStream('''PackageSet{package{
-		    Package diagnostic_msgs{ spec { 
-		      TopicSpec DiagnosticArray{ message { Header header DiagnosticStatus[] status }}  
-		    }},
-		    Package sensor_msgs{ spec { 
-		      TopicSpec LaserScan{ message { Header header float32 angle_min float32 angle_max float32 angle_increment float32 time_increment float32 scan_time float32 range_min float32 range_max float32[] ranges float32[] intensities }}
-		    }},
-		    Package std_msgs{ spec { 
-		    	TopicSpec Bool{ message { bool data }}, 		      
-		    }}
-		  }
-		}'''), emptyMap)
-
-		return resourceSet
-	}
+	
 
 }

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosGeneratorTest.xtend
@@ -1,0 +1,197 @@
+package de.fraunhofer.ipa.ros.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import de.fraunhofer.ipa.roscode.generator.RosCodeGenerator
+import org.eclipse.xtext.testing.util.ParseHelper
+import ros.PackageSet
+import org.eclipse.xtext.generator.InMemoryFileSystemAccess
+import org.eclipse.xtext.generator.GeneratorContext
+import de.fraunhofer.ipa.roscode.generator.CustomOutputProvider
+import com.google.inject.Provider
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.util.StringInputStream
+import org.eclipse.emf.ecore.resource.ResourceSet
+import de.fraunhofer.ipa.roscode.generator.Ros2CodeGenerator
+
+@RunWith(XtextRunner)
+@InjectWith(RosInjectorProvider)
+class RosGeneratorTest {
+	@Inject
+	RosCodeGenerator rosGenerator
+	
+	@Inject
+	Ros2CodeGenerator ros2Generator
+
+	@Inject
+	ParseHelper<PackageSet> parseHelper
+
+	@Inject
+	Provider<XtextResourceSet> resourceSetProvider
+
+	@Test
+	def void testGeneratedRosCode() {
+		val resourceSet = getMessagesResourceSet
+		val model = parseHelper.parse('''
+			PackageSet { package { 
+			  CatkinPackage cob_sick_s300 { artifact {
+			    Artifact cob_sick_s300 {
+			      node Node { name cob_sick_s300
+			        publisher {
+			          Publisher { name 'scan' message 'sensor_msgs.LaserScan'},
+			          Publisher { name 'scan_standby' message 'std_msgs.Bool'},
+			          Publisher { name '/diagnostics' message 'diagnostic_msgs.DiagnosticArray'}}
+			}}}}}}
+		''', resourceSet)
+
+		val fsa = new InMemoryFileSystemAccess
+		rosGenerator.doGenerate(model.eResource, fsa, new GeneratorContext)
+
+		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp"))
+		Assert.assertEquals('''#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+#include <std_msgs/Bool.h>
+#include <diagnostic_msgs/DiagnosticArray.h>
+
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "cob_sick_s300");
+  ros::NodeHandle n;
+  
+  ros::Publisher scan_pub = n.advertise<sensor_msgs::LaserScan>("scan", 10);
+  ros::Publisher scan_standby_pub = n.advertise<std_msgs::Bool>("scan_standby", 10);
+  ros::Publisher /diagnostics_pub = n.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 10);
+
+  ros::spin();
+
+  return 0;
+}'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
+	}
+	
+	@Test
+	def void testGeneratedRos2Code() {
+		val resourceSet = getMessagesResourceSet
+		
+		val model = parseHelper.parse('''
+			PackageSet { package { 
+			  CatkinPackage cob_sick_s300 { artifact {
+			    Artifact cob_sick_s300 {
+			      node Node { name cob_sick_s300
+			        publisher {
+			          Publisher { name 'scan' message 'sensor_msgs.LaserScan'},
+			          Publisher { name 'scan_standby' message 'std_msgs.Bool'},
+			          Publisher { name '/diagnostics' message 'diagnostic_msgs.DiagnosticArray'}}
+			}}}}}}
+		''', resourceSet)
+		
+		val fsa = new InMemoryFileSystemAccess
+		ros2Generator.doGenerate(model.eResource, fsa, new GeneratorContext)
+		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp"))
+		Assert.assertEquals('''#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+#include <sensor_msgs/msg/LaserScan.hpp>
+#include <std_msgs/msg/Bool.hpp>
+#include <diagnostic_msgs/msg/DiagnosticArray.hpp>
+
+void print_usage()
+{
+  printf("Usage for cob_sick_s300 app:\n");
+  printf("..... \n");
+  printf("..... \n");
+  printf("..... \n");
+
+}
+
+  class cob_sick_s300 : public rclcpp::Node {
+  	public:
+	  explicit cob_sick_s300(const std::string & scan scan_standby /diagnostics ) : Node("cob_sick_s300")
+	  auto publish_message = [this]() -> void {
+    	msg_scan_ = std::make_unique<sensor_msgs::msg::LaserScan>();
+    	scan_->publish(std::move(msg_scan_));
+    	msg_scan_standby_ = std::make_unique<std_msgs::msg::Bool>();
+    	scan_standby_->publish(std::move(msg_scan_standby_));
+    	msg_/diagnostics_ = std::make_unique<diagnostic_msgs::msg::DiagnosticArray>();
+    	/diagnostics_->publish(std::move(msg_/diagnostics_));
+	  };
+
+	  rclcpp::QoS qos(rclcpp::KeepLast(7));
+scan_ = this->create_publisher<sensor_msgs::msg::LaserScan>(scan, qos);
+scan_standby_ = this->create_publisher<std_msgs::msg::Bool>(scan_standby, qos);
+/diagnostics_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(/diagnostics, qos);
+}
+
+private:
+  size_t count_ = 1;
+  std::unique_ptr<sensor_msgs::msg::LaserScan> msg_scan_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_;
+  std::unique_ptr<std_msgs::msg::Bool> msg_scan_standby_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr scan_standby_;
+  std::unique_ptr<diagnostic_msgs::msg::DiagnosticArray> msg_/diagnostics_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr /diagnostics_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char * argv[])
+{
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
+    print_usage();
+    return 0;
+  }
+
+  rclcpp::init(argc, argv);
+  auto scan = std::string("scan");
+  auto scan_standby = std::string("scan_standby");
+  auto /diagnostics = std::string("/diagnostics");
+  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-t");
+  if (nullptr != cli_option) {
+  scan = std::string(cli_option);
+  scan_standby = std::string(cli_option);
+  /diagnostics = std::string(cli_option);
+  }
+   auto node = std::make_shared<cob_sick_s300>(scan)
+   auto node = std::make_shared<cob_sick_s300>(scan_standby)
+   auto node = std::make_shared<cob_sick_s300>(/diagnostics)
+
+  rclcpp::spin(cob_sick_s300);
+
+  rclcpp::shutdown();
+  return 0;
+}'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "cob_sick_s300.cpp").toString.trim)
+	}
+	
+	def ResourceSet getMessagesResourceSet() {
+		val resourceSet = resourceSetProvider.get
+
+		val messages = resourceSet.createResource(URI.createURI("common_msgs.ros"))
+		messages.load(new StringInputStream('''PackageSet{package{
+		    Package diagnostic_msgs{ spec { 
+		      TopicSpec DiagnosticArray{ message { Header header DiagnosticStatus[] status }}  
+		    }},
+		    Package sensor_msgs{ spec { 
+		      TopicSpec LaserScan{ message { Header header float32 angle_min float32 angle_max float32 angle_increment float32 time_increment float32 scan_time float32 range_min float32 range_max float32[] ranges float32[] intensities }}
+		    }},
+		    Package std_msgs{ spec { 
+		    	TopicSpec Bool{ message { bool data }}, 		      
+		    }}
+		  }
+		}'''), emptyMap)
+
+		return resourceSet
+	}
+
+}

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosTestingUtils.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosTestingUtils.xtend
@@ -1,0 +1,37 @@
+package de.fraunhofer.ipa.ros.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.util.StringInputStream
+import org.eclipse.emf.ecore.resource.ResourceSet
+import com.google.inject.Provider
+import org.eclipse.xtext.resource.XtextResourceSet
+
+@InjectWith(RosInjectorProvider)
+class RosTestingUtils {
+	
+	@Inject
+	Provider<XtextResourceSet> resourceSetProvider
+	
+	def ResourceSet getMessagesResourceSet() {
+		val resourceSet = resourceSetProvider.get
+
+		val messages = resourceSet.createResource(URI.createURI("msgs.ros"))
+		messages.load(new StringInputStream('''PackageSet{package{
+		    Package diagnostic_msgs{ spec { 
+		      TopicSpec DiagnosticArray{ message { Header header DiagnosticStatus[] status }}  
+		    }},
+		    Package sensor_msgs{ spec { 
+		      TopicSpec LaserScan{ message { Header header float32 angle_min float32 angle_max float32 angle_increment float32 time_increment float32 scan_time float32 range_min float32 range_max float32[] ranges float32[] intensities }}
+		    }},
+		    Package std_msgs{ spec { 
+		    	TopicSpec Bool{ message { bool data }}, 		      
+		    }}
+		  }
+		}'''), emptyMap)
+
+		return resourceSet
+	}
+	
+}

--- a/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosValidationTest.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext.tests/src/de/fraunhofer/ipa/ros/tests/RosValidationTest.xtend
@@ -1,0 +1,74 @@
+package de.fraunhofer.ipa.ros.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import ros.PackageSet
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
+import org.eclipse.xtext.diagnostics.Diagnostic
+import ros.RosPackage
+import de.fraunhofer.ipa.ros.validation.RosValidator
+
+@RunWith(XtextRunner)
+@InjectWith(RosInjectorProvider)
+class RosValidationTest {
+	
+	@Inject
+	ParseHelper<PackageSet> parseHelper
+	
+	@Inject 
+	ValidationTestHelper validationTester
+	
+	@Inject
+	RosTestingUtils rosTestingUtils
+	
+	@Test
+	def void successfulValidationTest(){
+		val resourceSet = rosTestingUtils.getMessagesResourceSet
+		val model = parseHelper.parse('''
+			PackageSet { package { 
+			  CatkinPackage cob_sick_s300 { artifact {
+			    Artifact cob_sick_s300 {
+			      node Node { name cob_sick_s300
+			        publisher {
+			          Publisher { name 'scan' message 'sensor_msgs.LaserScan'},
+			          Publisher { name 'scan_standby' message 'std_msgs.Bool'},
+			          Publisher { name '/diagnostics' message 'diagnostic_msgs.DiagnosticArray'}}
+			}}}}}}
+		''', resourceSet)
+		Assert.assertNotNull(model) 
+		validationTester.assertNoIssues(model)	
+	}
+	
+	@Test
+	def void validationErrorsTest(){
+		val model = parseHelper.parse('''
+		PackageSet { package { 
+		  CatkinPackage rplidar_ros { artifact {
+		    Artifact rplidarNode {
+		      node Node { name rplidarNode
+		        serviceserver {
+		          ServiceServer { name 'stop_motor' service 'std_srvs.Empty'},
+		          ServiceServer { name 'start_motor' service 'std_srvs.Empty'}}
+		        publisher {
+		          Publisher { name 'scan' message 'sensor_msgs.LaserScan'}}
+		}}}}}}
+	''')
+		Assert.assertNotNull(model)
+		
+		// Assert that the validation fails if the needed messages are not present
+		validationTester.assertWarning(model, RosPackage.Literals.ARTIFACT, RosValidator::INVALID_NAME)
+		validationTester.assertWarning(model, RosPackage.Literals.NODE, RosValidator::INVALID_NAME)
+		
+		// Assert that the custom validation rules are applied
+		validationTester.assertError(model, RosPackage.Literals.PUBLISHER, Diagnostic.LINKING_DIAGNOSTIC)
+		validationTester.assertError(model, RosPackage.Literals.SERVICE_SERVER, Diagnostic.LINKING_DIAGNOSTIC)
+	}
+	
+	
+	
+}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/META-INF/MANIFEST.MF
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,8 @@ Require-Bundle: de.fraunhofer.ipa.rossystem.xtext,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ de.fraunhofer.ipa.componentInterface.xtext.tests,
+ de.fraunhofer.ipa.ros.xtext.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: de.fraunhofer.ipa.rossystem.tests;x-internal=true

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/build.properties
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/build.properties
@@ -1,6 +1,7 @@
 source.. = src/,\
            src-gen/,\
-           xtend-gen/
+           xtend-gen/,\
+           resources/
 bin.includes = .,\
                META-INF/
 bin.excludes = **/*.xtend

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/scan_system.launch
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/scan_system.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+
+	<node pkg="cob_sick_s300" type="cob_sick_s300" name="base_laser_front" ns="base_laser_front" cwd="node" respawn="false" output="screen">
+
+	</node>
+</launch>

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/scan_systeminstall.sh
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/scan_systeminstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+distro=$(echo $ROS_DISTRO)
+
+if [ -z "$distro" ]; then 
+    echo "Ros distro variable not found"
+    read -p "Do you want to install ROS? [Y/N]" choice
+    if [[ "$choice" == "Y" ]]; then
+            read -p "Distro version (e.g. kinetic, melodic): " distro
+            sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt update
+            sudo apt install ros-$distro-desktop
+    else
+        exit
+    fi
+else
+    echo "Found a ROS installation for the $distro distro"
+    sudo apt update
+fi
+
+for pkg in cob-sick-s300 
+do
+    sudo apt install ros-$distro-$pkg
+done

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/CustomInjectorProvider.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/CustomInjectorProvider.xtend
@@ -1,0 +1,14 @@
+package de.fraunhofer.ipa.rossystem.tests
+
+import de.fraunhofer.ipa.ros.tests.RosInjectorProvider
+import de.fraunhofer.ipa.componentInterface.tests.ComponentInterfaceInjectorProvider
+
+class CustomInjectorProvider extends RosSystemInjectorProvider {
+	
+	override protected internalCreateInjector() {
+		// trigger the injector creation of all three languages
+		new RosInjectorProvider().injector
+		new ComponentInterfaceInjectorProvider().injector	
+		super.internalCreateInjector()
+	}
+}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemGeneratorTest.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemGeneratorTest.xtend
@@ -1,0 +1,119 @@
+package de.fraunhofer.ipa.rossystem.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import rossystem.RosSystem
+import de.fraunhofer.ipa.rossystem.generator.CustomOutputProvider
+import de.fraunhofer.ipa.rossystem.generator.RosSystemGenerator
+import org.eclipse.xtext.generator.InMemoryFileSystemAccess
+import org.eclipse.xtext.generator.GeneratorContext
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.resource.XtextResourceSet
+import com.google.inject.Provider
+import org.eclipse.xtext.util.StringInputStream
+
+@RunWith(typeof(XtextRunner))
+@InjectWith(typeof(CustomInjectorProvider))
+class RosSystemGeneratorTest {
+
+	@Inject
+	ParseHelper<RosSystem> parseHelper
+	
+	@Inject
+	Provider<XtextResourceSet> resourceSetProvider
+	
+	@Inject 
+	RosSystemGenerator generator
+
+	@Test
+	def void testGeneratedCode() {
+
+		val resourceSet = resourceSetProvider.get
+		val sickS300Example = resourceSet.createResource(URI.createURI("sick_s300.ros"))
+		sickS300Example.load(new StringInputStream('''
+			PackageSet { package {
+				CatkinPackage cob_sick_s300 { artifact {
+					Artifact cob_sick_s300 { node Node { name cob_sick_s300 
+						publisher { 
+						Publisher { name scan message "sensor_msgs.LaserScan" } , 
+						Publisher { name diagnostics message "diagnostic_msgs.DiagnosticArray" 
+						}}}}
+			}}}}
+		'''), emptyMap)
+
+		val model = parseHelper.parse('''
+			RosSystem { Name 'scan_system' 
+			RosComponents ( ComponentInterface 
+				{ name base_laser_front NameSpace base_laser_front 
+					RosPublishers { 
+						RosPublisher "base_laser_front/scan" 
+							{ ns base_laser_front RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.scan" } , 
+						RosPublisher "base_laser_front/diagnostics" 
+							{ ns base_laser_front RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.diagnostics" } 
+							} }
+							) 
+					}
+				 ''', resourceSet)
+
+		val fsa = new InMemoryFileSystemAccess
+		
+		generator.doGenerate(model.eResource, fsa, new GeneratorContext)
+		
+		// Assert that all necessary files exist 
+		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "scan_system.launch"))
+		Assert.assertTrue(fsa.textFiles.containsKey(CustomOutputProvider::DEFAULT_OUTPUT + "scan_systeminstall.sh"))
+		Assert.assertTrue(
+			fsa.textFiles.containsKey(CustomOutputProvider::CM_CONFIGURATION + "scan_system.componentinterface"))
+		
+		// Test the generated launch file
+		Assert.assertEquals(
+            '''<?xml version="1.0"?>
+<launch>
+
+	<node pkg="cob_sick_s300" type="cob_sick_s300" name="base_laser_front" ns="base_laser_front" cwd="node" respawn="false" output="screen">
+
+	</node>
+</launch>'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT+"scan_system.launch").toString.trim)
+		
+		
+		// Test the generated install script
+		Assert.assertEquals('''#!/bin/bash
+
+distro=$(echo $ROS_DISTRO)
+
+if [ -z "$distro" ]; then 
+    echo "Ros distro variable not found"
+    read -p "Do you want to install ROS? [Y/N]" choice
+    if [[ "$choice" == "Y" ]]; then
+            read -p "Distro version (e.g. kinetic, melodic): " distro
+            sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt update
+            sudo apt install ros-$distro-desktop
+    else
+        exit
+    fi
+else
+    echo "Found a ROS installation for the $distro distro"
+    sudo apt update
+fi
+
+for pkg in cob-sick-s300 
+do
+    sudo apt install ros-$distro-$pkg
+done'''.toString, fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT + "scan_systeminstall.sh").toString.trim)
+	
+	// Test the generated component interface		
+	Assert.assertEquals('''ComponentInterface { name scan_system
+RosPublishers{
+	RosPublisher "base_laser_front/scan" { RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.scan"},
+	RosPublisher "base_laser_front/diagnostics" { RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.diagnostics"}
+	}
+}'''.toString, fsa.textFiles.get(CustomOutputProvider::CM_CONFIGURATION + "scan_system.componentinterface").toString.trim)	
+	}
+}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
@@ -11,15 +11,10 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import rossystem.RosSystem
-import org.eclipse.xtext.testing.validation.ValidationTestHelper
-
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(RosSystemInjectorProvider))
 class RosSystemParsingTest {
-	
-	@Inject
-	ValidationTestHelper validationTestHelper
 
 	@Inject
 	ParseHelper<RosSystem> parseHelper

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
@@ -7,26 +7,22 @@ import com.google.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.util.ParseHelper
-import org.eclipse.xtext.xbase.testing.CompilationTestHelper
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import rossystem.RosSystem
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
 
-import static extension org.junit.Assert.*
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(RosSystemInjectorProvider))
 class RosSystemParsingTest {
-
-	@Rule
-	@Inject public TemporaryFolder temporaryFolder
+	
+	@Inject
+	ValidationTestHelper validationTestHelper
 
 	@Inject
 	ParseHelper<RosSystem> parseHelper
-	@Inject extension CompilationTestHelper
 
 	@Test
 	def void loadModel() {
@@ -110,30 +106,4 @@ class RosSystemParsingTest {
         Assert.assertEquals(ToTopic, diag_Subscriber)
 
     }
-/** 
-	@Test
-    def void testGeneratedCode(){
-    	'''
-	RosSystem { Name 'My' 
-	  RosComponents ( 
-	    ComponentInterface { name scan_front NameSpace scan_front RosPublishers { RosPublisher "scan_front/scan" { ns scan_front RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.scan" } , RosPublisher "scan_front/diagnostics" { ns scan_front RefPublisher "cob_sick_s300.cob_sick_s300.cob_sick_s300.diagnostics" } } } , 
-	    ComponentInterface { name diagnostics RosPublishers { RosPublisher diagnostics_toplevel_state { RefPublisher "diagnostic_aggregator.aggregator_node.aggregator_node.diagnostics_toplevel_state" } } RosSubscribers { RosSubscriber diagnostics { RefSubscriber "diagnostic_aggregator.aggregator_node.aggregator_node.diagnostics" } } } ) 
-	  TopicConnections { 
-	    TopicConnection "scan_front/diagnostics" { From ( "scan_front.scan_front/diagnostics" ) To ( "diagnostics.diagnostics" )}}}
-    '''.assertCompilesTo('''
-<?xml version="1.0"?>
-<launch>
-
-	<node pkg="cob_sick_s300" type="cob_sick_s300" name="scan_front" ns="scan_front" cwd="node" respawn="false" output="screen">
-
-	</node>
-
-	<node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostics" cwd="node" respawn="false" output="screen">
-		<remap from="diagnostics" to="scan_front/diagnostics" />
-
-	</node>
-</launch>'''
-			)
-    	
-    }*/
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/RosSystemRuntimeModule.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/RosSystemRuntimeModule.xtend
@@ -5,7 +5,9 @@ package de.fraunhofer.ipa.rossystem
 
 import org.eclipse.xtext.generator.IOutputConfigurationProvider
 import de.fraunhofer.ipa.rossystem.generator.CustomOutputProvider
+import de.fraunhofer.ipa.rossystem.generator.RosSystemGenerator
 import com.google.inject.Binder
+import org.eclipse.xtext.generator.AbstractGenerator
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -13,8 +15,8 @@ import com.google.inject.Binder
 class RosSystemRuntimeModule extends AbstractRosSystemRuntimeModule {
 		
 	override void configure(Binder binder) {
-	super.configure(binder)
-	binder.bind(IOutputConfigurationProvider).to(CustomOutputProvider).asEagerSingleton()
+		super.configure(binder)
+		binder.bind(IOutputConfigurationProvider).to(CustomOutputProvider).asEagerSingleton()
 	}
 
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/RosSystemRuntimeModule.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/RosSystemRuntimeModule.xtend
@@ -5,9 +5,8 @@ package de.fraunhofer.ipa.rossystem
 
 import org.eclipse.xtext.generator.IOutputConfigurationProvider
 import de.fraunhofer.ipa.rossystem.generator.CustomOutputProvider
-import de.fraunhofer.ipa.rossystem.generator.RosSystemGenerator
 import com.google.inject.Binder
-import org.eclipse.xtext.generator.AbstractGenerator
+
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.


### PR DESCRIPTION
@ipa-nhg as discussed, this PR adds some unit tests for the code generators (for now, there is one for ROS, one for ROS2 and one where the generated files from the rossystem files are tested). I hope they can be easily extended

In addition, while researching about the unit tests, I saw that also a "validationTestHelper" is offered - with it, it can be tested whether all links in the models are resolved (e.g. if the links to the messages can be resolved successfully) and the validation rules are applied. I've added some examples for the ros language