### PR TITLE
Add first draft for the ROS2 launch files generator

### DIFF
--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test.rossystem
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test.rossystem
@@ -15,17 +15,17 @@ RosSystem { Name 'test_system'  RosComponents (
     	}
     } , ComponentInterface { name test_node2 NameSpace test2 
     	FromRosNode "test_pkg.test_node.test_node"
-    	RosPublishers { RosPublisher "test2/scan" { ns test2 RefPublisher "test_pkg.test_node.test_node.scan" } } 
-    	RosSubscribers { RosSubscriber "test2/power_state" { ns test2 RefSubscriber "test_pkg.test_node.test_node.power_state" } } 
-    	RosSrvServers { RosServiceServer "test2/setBool" { ns test2 RefServer "test_pkg.test_node.test_node.setBool" } } 
-    	RosSrvClients { RosServiceClient "test2/init" { ns test2 RefClient "test_pkg.test_node.test_node.init" } } 
-    	RosParameters { RosParameter "test2/string_test" { ns test2 RefParameter "test_pkg.test_node.test_node.string_test" } , 
-    		RosParameter "test2/bool_tets" { ns test2 RefParameter "test_pkg.test_node.test_node.bool_tets" } , 
-    		RosParameter "test2/array_tets" { ns test2 RefParameter "test_pkg.test_node.test_node.array_tets" } , 
-    		RosParameter "test2/base64_test" { ns test2 RefParameter "test_pkg.test_node.test_node.base64_test" } , 
-    		RosParameter "test2/double_test" { ns test2 RefParameter "test_pkg.test_node.test_node.double_test" } , 
-    		RosParameter "test2/int_test" { ns test2 RefParameter "test_pkg.test_node.test_node.int_test" } , 
-    		RosParameter "test2/list_test" { ns test2 RefParameter "test_pkg.test_node.test_node.list_test" }
+    	RosPublishers { RosPublisher "scan" {  RefPublisher "test_pkg.test_node.test_node.scan" } } 
+    	RosSubscribers { RosSubscriber "power_state" { RefSubscriber "test_pkg.test_node.test_node.power_state" } } 
+    	RosSrvServers { RosServiceServer "setBool" { RefServer "test_pkg.test_node.test_node.setBool" } } 
+    	RosSrvClients { RosServiceClient "init" { RefClient "test_pkg.test_node.test_node.init" } } 
+    	RosParameters { RosParameter "string_test" { RefParameter "test_pkg.test_node.test_node.string_test" } , 
+    		RosParameter "bool_tets" { RefParameter "test_pkg.test_node.test_node.bool_tets" } , 
+    		RosParameter "array_tets" { RefParameter "test_pkg.test_node.test_node.array_tets" } , 
+    		RosParameter "base64_test" { RefParameter "test_pkg.test_node.test_node.base64_test" } , 
+    		RosParameter "double_test" { RefParameter "test_pkg.test_node.test_node.double_test" } , 
+    		RosParameter "int_test" { RefParameter "test_pkg.test_node.test_node.int_test" } , 
+    		RosParameter "list_test" { RefParameter "test_pkg.test_node.test_node.list_test" }
     	}
     } , ComponentInterface { name test_nodea 
     	RosPublishers { RosPublisher power_state { RefPublisher "test_pkg.test_node.test_node.power_state" } } 
@@ -33,7 +33,7 @@ RosSystem { Name 'test_system'  RosComponents (
     	RosSrvServers { RosServiceServer init { RefServer "test_pkg.test_node.test_node.init" } } 
     	RosSrvClients { RosServiceClient SetBool { RefClient "test_pkg.test_node.test_node.SetBool" } }
     } ) TopicConnections { 
-    	TopicConnection scan { From ( "test_node.scan" ) To ( "test_nodea.scan" ) } , 
+    	TopicConnection scan_rename { From ( "test_node.scan" ) To ( "test_nodea.scan" ) } , 
     	TopicConnection power_state { From ( "test_nodea.power_state" ) To ( "test_node.power_state" ) }
     } ServiceConnections { ServiceConnection init { From ( "test_nodea.init" ) To "test_node.init" } }
        Parameters { 

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test_system.componentinterface
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test_system.componentinterface
@@ -1,22 +1,18 @@
 ComponentInterface { name test_system
 RosPublishers{
 	RosPublisher "scan" { RefPublisher "test_pkg.test_node.test_node.scan"},
-	RosPublisher "test2/scan" { RefPublisher "test_pkg.test_node.test_node.scan"},
 	RosPublisher "power_state" { RefPublisher "test_pkg.test_node.test_node.power_state"}
 	}
 RosSubscribers{
 	RosSubscriber "power_state" { RefSubscriber "test_pkg.test_node.test_node.power_state"},
-	RosSubscriber "test2/power_state" { RefSubscriber "test_pkg.test_node.test_node.power_state"},
 	RosSubscriber "scan" { RefSubscriber "test_pkg.test_node.test_node.scan"}
 	}
 RosSrvServers{
 	RosServiceServer "setBool" { RefServer "test_pkg.test_node.test_node.setBool"},
-	RosServiceServer "test2/setBool" { RefServer "test_pkg.test_node.test_node.setBool"},
 	RosServiceServer "init" { RefServer "test_pkg.test_node.test_node.init"}
 	}
 RosSrvClients{
 	RosServiceClient "init" { RefClient "test_pkg.test_node.test_node.init"},
-	RosServiceClient "test2/init" { RefClient "test_pkg.test_node.test_node.init"},
 	RosServiceClient "SetBool" { RefClient "test_pkg.test_node.test_node.SetBool"}
 	}
 RosParameters{

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test_system/launch/test_system.launch
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/resources/test_system/launch/test_system.launch
@@ -4,15 +4,17 @@
   <rosparam param="list">[1,2,a]</rosparam>
   <rosparam param="list">[1,3]</rosparam>
   <rosparam>
-first_element:8
-third_element:dsd
+first_element: 8
+third_element: dsd
   </rosparam>
-
+                               
   <node pkg="test_pkg" type="test_node" name="test_node" cwd="node" respawn="false" output="screen">
+    <remap from='scan' to='scan_rename' />
   </node>
   <node pkg="test_pkg" type="test_node" name="test_node2" ns="test2" cwd="node" respawn="false" output="screen">
   </node>
   <node pkg="test_pkg" type="test_node" name="test_nodea" cwd="node" respawn="false" output="screen">
+    <remap from='scan' to='scan_rename' />
   </node>
 
 </launch>

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemGeneratorTest.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemGeneratorTest.xtend
@@ -102,7 +102,15 @@ class RosSystemGeneratorTest {
 		
 		// Test the generated launch file
 		Assert.assertEquals(new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR+'/test_system/launch/', 'test_system.launch'))).trim,
-        fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT+'test_system/launch/test_system.launch').toString.trim)
+		fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT+'test_system/launch/test_system.launch').toString.trim)
+        
+		// Test the generated package.xml file
+		Assert.assertEquals(new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR+'/test_system/', 'package.xml'))).trim,
+		fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT+'test_system/package.xml').toString.trim)
+        
+		// Test the generated CMakeLists.txt file
+		Assert.assertEquals(new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR+'/test_system/', 'CMakeLists.txt'))).trim,
+		fsa.textFiles.get(CustomOutputProvider::DEFAULT_OUTPUT+'test_system/CMakeLists.txt').toString.trim)
 
 		// Test the generated component interface					
 		Assert.assertEquals(new String(Files.readAllBytes(Paths.get(RESOURCES_BASE_DIR+'/test_system.componentinterface'))).trim,

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext.tests/src/de/fraunhofer/ipa/rossystem/tests/RosSystemParsingTest.xtend
@@ -42,7 +42,7 @@ class RosSystemParsingTest {
        	Assert.assertEquals("test_node", ComponentName)
         
         val TopicConnectionName = model.topicConnections.get(0).topicName
-        Assert.assertEquals("scan", TopicConnectionName)
+        Assert.assertEquals("scan_rename", TopicConnectionName)
         
         val FromTopic = model.topicConnections.get(0).from.get(0).name
         val Publisher = model.rosComponent.get(0).rospublisher.get(0).name

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/CMakeListsCompiler.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/CMakeListsCompiler.xtend
@@ -8,7 +8,7 @@ class CMakeListsCompiler {
 	@Inject extension GeneratorHelpers
 	
 	
-	def compile_CMakeLists(RosSystem system) '''«init_pkg()»
+	def compile_CMakeLists_ROS1(RosSystem system) '''«init_pkg()»
 cmake_minimum_required(VERSION 2.8.3)
 project(«system.name.toLowerCase»)
 
@@ -21,5 +21,29 @@ catkin_package()
 install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )'''
+
+	def compile_CMakeLists_ROS2(RosSystem system) '''«init_pkg()»
+cmake_minimum_required(VERSION 3.5)
+project(«system.name.toLowerCase»)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+### INSTALL ###
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()
+'''
+
 
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
@@ -12,14 +12,14 @@ import ros.Subscriber
 import rossystem.RosSystem
 import java.util.List
 import ros.Node
+import ros.impl.PackageImpl
 
 class GeneratorHelpers {
 	
 	boolean PackageSet
 	
-	String package_impl
+	PackageImpl package_impl
 	List<CharSequence> PkgsList
-	String package_name
 	String Pkg
 
 	def void init_pkg(){
@@ -42,41 +42,36 @@ class GeneratorHelpers {
 '''«IF !(component.fromRosNode===null) »«component.fromRosNode.getPackage_node»«ELSEIF !PackageSet && !component.rospublisher.empty»«FOR Rospublisher:component.rospublisher»«IF !PackageSet»«Rospublisher.publisher.getPackage_pub()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rossubscriber.empty»«FOR Rossubscriber:component.rossubscriber»«IF !PackageSet»«Rossubscriber.subscriber.getPackage_sub()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosserviceserver.empty»«FOR Rosserviceserver:component.rosserviceserver»«IF !PackageSet»«Rosserviceserver.srvserver.getPackage_srvserv()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosserviceclient.empty»«FOR Rosserviceclient:component.rosserviceclient»«IF !PackageSet»«Rosserviceclient.srvclient.getPackage_srvcli()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosparameter.empty»«FOR Rosparameter:component.rosparameter»«IF !PackageSet»«Rosparameter.parameter.getPackage_rosparam()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosactionserver.empty»«FOR RosActionSever:component.rosactionserver»«IF !PackageSet»«RosActionSever.actserver.getPackage_actserver()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosactionclient.empty»«FOR RosActionClient:component.rosactionclient»«IF !PackageSet»«RosActionClient.actclient.getPackage_actclient()»«ENDIF»«ENDFOR»«ENDIF»'''
 
 	def getPackage_pub(Publisher publisher){
-		package_impl = publisher.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = publisher.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_sub(Subscriber subscriber){
-		package_impl = subscriber.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = subscriber.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_srvserv(ServiceServer serviceserver){
-		package_impl = serviceserver.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = serviceserver.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_srvcli(ServiceClient serviceclient){
-		package_impl = serviceclient.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = serviceclient.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_actserver(ActionServer actionserver){
-		package_impl = actionserver.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = actionserver.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_actclient(ActionClient actionclient){
-		package_impl = actionclient.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = actionclient.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_rosparam (Parameter param){
-		package_impl = param.eContainer.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = param.eContainer.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 	def getPackage_node (Node node){
-		package_impl = node.eContainer.eContainer.toString;
-		return package_impl.getPackage;
+		package_impl = node.eContainer.eContainer as PackageImpl;
+		return package_impl.name;
 	}
 
-	def getPackage(String package_impl){
-			package_name = package_impl.substring(package_impl.indexOf("name")+6,package_impl.length-1)
-			PackageSet=true;
-			return package_name;
-	}
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/GeneratorHelpers.xtend
@@ -40,7 +40,6 @@ class GeneratorHelpers {
 	
 	def compile_pkg(ComponentInterface component)
 '''«IF !(component.fromRosNode===null) »«component.fromRosNode.getPackage_node»«ELSEIF !PackageSet && !component.rospublisher.empty»«FOR Rospublisher:component.rospublisher»«IF !PackageSet»«Rospublisher.publisher.getPackage_pub()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rossubscriber.empty»«FOR Rossubscriber:component.rossubscriber»«IF !PackageSet»«Rossubscriber.subscriber.getPackage_sub()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosserviceserver.empty»«FOR Rosserviceserver:component.rosserviceserver»«IF !PackageSet»«Rosserviceserver.srvserver.getPackage_srvserv()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosserviceclient.empty»«FOR Rosserviceclient:component.rosserviceclient»«IF !PackageSet»«Rosserviceclient.srvclient.getPackage_srvcli()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosparameter.empty»«FOR Rosparameter:component.rosparameter»«IF !PackageSet»«Rosparameter.parameter.getPackage_rosparam()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosactionserver.empty»«FOR RosActionSever:component.rosactionserver»«IF !PackageSet»«RosActionSever.actserver.getPackage_actserver()»«ENDIF»«ENDFOR»«ELSEIF !PackageSet && !component.rosactionclient.empty»«FOR RosActionClient:component.rosactionclient»«IF !PackageSet»«RosActionClient.actclient.getPackage_actclient()»«ENDIF»«ENDFOR»«ENDIF»'''
-	
 
 	def getPackage_pub(Publisher publisher){
 		package_impl = publisher.eContainer.eContainer.eContainer.toString;

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
@@ -8,6 +8,16 @@ import org.eclipse.emf.ecore.EObject
 import ros.ParameterValue
 import rossystem.RosSystem
 import ros.impl.ParameterStructMemberImpl
+import componentInterface.RosPublisher
+import org.eclipse.emf.common.util.EList
+import rossystem.TopicConnection
+import componentInterface.RosSubscriber
+import componentInterface.RosServiceServer
+import rossystem.ServiceConnection
+import componentInterface.RosServiceClient
+import componentInterface.RosActionClient
+import rossystem.ActionConnection
+import componentInterface.RosActionServer
 
 class LaunchFileCompiler_ROS1 {
 	@Inject extension GeneratorHelpers
@@ -22,7 +32,7 @@ class LaunchFileCompiler_ROS1 {
 	
 	int i=0;
 	int k=0;
-
+	
 	def compile_toROS1launch(RosSystem system) '''«init_comp()»
 <?xml version="1.0"?>
 <launch>
@@ -47,112 +57,58 @@ class LaunchFileCompiler_ROS1 {
   		<param name="«ROSParameter.name»" value="«compile_param_value(ROSParameter.value)»"/>
   	«ENDIF»
   «ENDFOR»
-	«FOR component:system.rosComponent»
-		«FOR rosPublisher:component.rospublisher»
-				«IF component.hasNS»«IF !rosPublisher.name.equals(compile_topic_name(rosPublisher.publisher,component.get_ns()))»
-				<remap from=«compile_topic_name(rosPublisher.publisher,component.get_ns())» to=«rosPublisher.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-		«FOR rosSubscriber:component.rossubscriber»
-				«IF component.hasNS»«IF !rosSubscriber.name.equals(compile_topic_name(rosSubscriber.subscriber,component.get_ns()))»
-				<remap from=«compile_topic_name(rosSubscriber.subscriber,component.get_ns())» to=«rosSubscriber.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-		«FOR rosServiceServer:component.rosserviceserver»
-				«IF component.hasNS»«IF !rosServiceServer.name.equals(compile_service_name(rosServiceServer.srvserver,component.get_ns()))»
-				<remap from=«compile_service_name(rosServiceServer.srvserver,component.get_ns())» to=«rosServiceServer.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-		«FOR rosServiceClient:component.rosserviceclient»
-				«IF component.hasNS»«IF !rosServiceClient.name.equals(compile_service_name(rosServiceClient.srvclient,component.get_ns()))»
-				<remap from=«compile_service_name(rosServiceClient.srvclient,component.get_ns())» to=«rosServiceClient.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-		«FOR rosActionServer:component.rosactionserver»
-				«IF component.hasNS»«IF !rosActionServer.name.equals(compile_action_name(rosActionServer.actserver,component.get_ns()))»
-				<remap from=«compile_action_name(rosActionServer.actserver,component.get_ns())» to=«rosActionServer.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-		«FOR rosActionClient:component.rosactionclient»
-				«IF component.hasNS»«IF !rosActionClient.name.equals(compile_action_name(rosActionClient.actclient,component.get_ns()))»
-				<remap from=«compile_action_name(rosActionClient.actclient,component.get_ns())» to=«rosActionClient.name» />
-				«ENDIF»«ENDIF»
-		«ENDFOR»
-	«ENDFOR»
+«««	«FOR component:system.rosComponent»
+ «««		«FOR rosPublisher:component.rospublisher»
+ «««				«IF component.hasNS»«IF !rosPublisher.name.equals(compile_topic_name(rosPublisher.publisher,component.get_ns()))»
+ «««				<remap from=«compile_topic_name(rosPublisher.publisher,component.get_ns())» to=«rosPublisher.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««		«FOR rosSubscriber:component.rossubscriber»
+ «««				«IF component.hasNS»«IF !rosSubscriber.name.equals(compile_topic_name(rosSubscriber.subscriber,component.get_ns()))»
+ «««				<remap from=«compile_topic_name(rosSubscriber.subscriber,component.get_ns())» to=«rosSubscriber.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««		«FOR rosServiceServer:component.rosserviceserver»
+ «««				«IF component.hasNS»«IF !rosServiceServer.name.equals(compile_service_name(rosServiceServer.srvserver,component.get_ns()))»
+ «««				<remap from=«compile_service_name(rosServiceServer.srvserver,component.get_ns())» to=«rosServiceServer.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««		«FOR rosServiceClient:component.rosserviceclient»
+ «««				«IF component.hasNS»«IF !rosServiceClient.name.equals(compile_service_name(rosServiceClient.srvclient,component.get_ns()))»
+ «««				<remap from=«compile_service_name(rosServiceClient.srvclient,component.get_ns())» to=«rosServiceClient.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««		«FOR rosActionServer:component.rosactionserver»
+ «««				«IF component.hasNS»«IF !rosActionServer.name.equals(compile_action_name(rosActionServer.actserver,component.get_ns()))»
+ «««				<remap from=«compile_action_name(rosActionServer.actserver,component.get_ns())» to=«rosActionServer.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««		«FOR rosActionClient:component.rosactionclient»
+ «««				«IF component.hasNS»«IF !rosActionClient.name.equals(compile_action_name(rosActionClient.actclient,component.get_ns()))»
+ «««				<remap from=«compile_action_name(rosActionClient.actclient,component.get_ns())» to=«rosActionClient.name» />
+ «««				«ENDIF»«ENDIF»
+ «««		«ENDFOR»
+ «««	«ENDFOR» 
 
 	«FOR component:system.rosComponent»
 	<node pkg="«component.compile_pkg»«init_pkg»" type="«component.compile_art»«init_comp()»" name="«component.name»"«IF component.hasNS» ns="«component.get_ns»"«ENDIF» cwd="node" respawn="false" output="screen">«init_comp()»«init_pkg»
 		«FOR rosPublisher:component.rospublisher»
-			«IF !rosPublisher.name.equals(compile_topic_name(rosPublisher.publisher,component.check_ns))»
-				<remap from="«rosPublisher.publisher.name»" to="«rosPublisher.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosPublisher)»
-					«IF !topicConnection.topicName.equals(rosPublisher.name)»
-					<remap from="«rosPublisher.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-			«ENDIF»
-		«ENDFOR»
+			«remapping_function_pub(rosPublisher, component.hasNS, inTopicFromConnection(rosPublisher, system.topicConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosSubscriber:component.rossubscriber»
-			«IF !rosSubscriber.name.equals(compile_topic_name(rosSubscriber.subscriber,component.check_ns))»
-				<remap from="«rosSubscriber.subscriber.name»" to="«rosSubscriber.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosSubscriber)»
-					«IF !topicConnection.topicName.equals(rosSubscriber.name)»
-					<remap from="«rosSubscriber.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-				«ENDIF»
-			«ENDFOR»
+			«remapping_function_sub(rosSubscriber, component.hasNS, inTopicToConnection(rosSubscriber, system.topicConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosServiceServer:component.rosserviceserver»
-			«IF !rosServiceServer.name.equals(compile_service_name(rosServiceServer.srvserver,component.check_ns))»
-				<remap from="«rosServiceServer.srvserver.name»" to="«rosServiceServer.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosServiceServer)»
-					«IF !topicConnection.topicName.equals(rosServiceServer.name)»
-					<remap from="«rosServiceServer.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-				«ENDIF»
-			«ENDFOR»
+			«remapping_function_srv(rosServiceServer, component.hasNS, inServiceFromConnection(rosServiceServer, system.serviceConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosServiceClient:component.rosserviceclient»
-			«IF !rosServiceClient.name.equals(compile_service_name(rosServiceClient.srvclient,component.check_ns))»
-				<remap from="«rosServiceClient.srvclient.name»" to="«rosServiceClient.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosServiceClient)»
-					«IF !topicConnection.topicName.equals(rosServiceClient.name)»
-					<remap from="«rosServiceClient.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-				«ENDIF»
-			«ENDFOR»
+			«remapping_function_client(rosServiceClient, component.hasNS, inServiceToConnection(rosServiceClient, system.serviceConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosActionServer:component.rosactionserver»
-			«IF !rosActionServer.name.equals(compile_action_name(rosActionServer.actserver,component.check_ns))»
-				<remap from="«rosActionServer.actserver.name»" to="«rosActionServer.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosActionServer)»
-					«IF !topicConnection.topicName.equals(rosActionServer.name)»
-					<remap from="«rosActionServer.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-				«ENDIF»
-			«ENDFOR»
+			«remapping_function_acts(rosActionServer, component.hasNS, inActionFromConnection(rosActionServer, system.actionConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosActionClient:component.rosactionclient»
-			«IF !rosActionClient.name.equals(compile_action_name(rosActionClient.actclient,component.check_ns))»
-				<remap from="«rosActionClient.actclient.name»" to="«rosActionClient.name»" />
-			«ENDIF»
-			«FOR topicConnection:system.topicConnections»
-				«IF topicConnection.from.contains(rosActionClient)»
-					«IF !topicConnection.topicName.equals(rosActionClient.name)»
-					<remap from="«rosActionClient.name»" to="«topicConnection.topicName»" />
-					«ENDIF»
-				«ENDIF»
-			«ENDFOR»
+			«remapping_function_actc(rosActionClient, component.hasNS, inActionToConnection(rosActionClient, system.actionConnections),component.check_ns)»
 		«ENDFOR»
 		«FOR rosParameter:component.rosparameter»
 			«IF rosParameter.parameter.type.toString.contains("ParameterStructType")»«str_output=""»
@@ -171,6 +127,133 @@ class LaunchFileCompiler_ROS1 {
 
 </launch>
 	'''
+	
+	// TOPICS REMAP
+	def String remapping_function_pub(RosPublisher rosPublisher, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (!(prefix(NS)+rosPublisher.publisher.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosPublisher.publisher.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosPublisher.publisher.name+"' to='"+inConnection+"' />"
+				}
+		}}else if (!((prefix(NS)+rosPublisher.name).equals(compile_topic_name(rosPublisher.publisher, NS)))){
+				return "<remap from='"+rosPublisher.publisher.name+"' to='"+rosPublisher.name+"' />";
+		}
+	}
+	def String remapping_function_sub(RosSubscriber rosSubscriber, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (! (prefix(NS)+rosSubscriber.subscriber.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosSubscriber.subscriber.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosSubscriber.subscriber.name+"' to='"+inConnection+"' />"
+				}
+		}} else if (!((prefix(NS)+rosSubscriber.name).equals(compile_topic_name(rosSubscriber.subscriber, NS)))){
+				return "<remap from='"+rosSubscriber.subscriber.name+"' to='"+rosSubscriber.name+"' />";
+		}
+	}
+	def String inTopicFromConnection(RosPublisher publisher, EList<TopicConnection> list) {
+		for (topicConnection:list){
+			if (topicConnection.from.contains(publisher)){
+				return topicConnection.topicName
+			} 
+		}
+		return null ;
+	}
+	def String inTopicToConnection(RosSubscriber subscriber, EList<TopicConnection> list) {
+		for (topicConnection:list){
+			if (topicConnection.to.contains(subscriber)){
+				return topicConnection.topicName
+			} 
+		}
+		return null ;
+	}
+	
+	// SERVICES REMAP
+	def String remapping_function_srv(RosServiceServer rosServiceServer, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (! (prefix(NS)+rosServiceServer.srvserver.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosServiceServer.srvserver.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosServiceServer.srvserver.name+"' to='"+inConnection+"' />"
+				}
+		}} else if (!((prefix(NS)+rosServiceServer.name).equals(compile_service_name(rosServiceServer.srvserver, NS)))){
+				return "<remap from='"+rosServiceServer.srvserver.name+"' to='"+rosServiceServer.name+"' />";
+		}
+	}
+	def String remapping_function_client(RosServiceClient rosServiceClient, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (! (prefix(NS)+rosServiceClient.srvclient.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosServiceClient.srvclient.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosServiceClient.srvclient.name+"' to='"+inConnection+"' />"
+				}
+		}} else if (!((prefix(NS)+rosServiceClient.name).equals(compile_service_name(rosServiceClient.srvclient, NS)))){
+				return "<remap from='"+rosServiceClient.srvclient.name+"' to='"+rosServiceClient.name+"' />";
+		}
+	}
+	def String inServiceFromConnection(RosServiceServer service, EList<ServiceConnection> list) {
+		for (serviceConnection:list){
+			if (serviceConnection.from.contains(service)){
+				return serviceConnection.serviceName
+			}
+		}
+		return null ;
+	}
+	def String inServiceToConnection(RosServiceClient client, EList<ServiceConnection> list) {
+		for (serviceConnection:list){
+			if (serviceConnection.to.equals(client)){
+				return serviceConnection.serviceName
+			}
+		}
+		return null ;
+	}
+	
+	// ACTIONS REMAP
+	def String remapping_function_acts(RosActionServer rosActionService, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (! (prefix(NS)+rosActionService.actserver.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosActionService.actserver.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosActionService.actserver.name+"' to='"+inConnection+"' />"
+				}
+		}} else if (!((prefix(NS)+rosActionService.name).equals(compile_action_name(rosActionService.actserver, NS)))){
+				return "<remap from='"+rosActionService.actserver.name+"' to='"+rosActionService.name+"' />";
+		}
+	}
+	def String remapping_function_actc(RosActionClient rosActionClient, boolean HasNS, String inConnection, String NS) {
+		if(inConnection!==null){
+			if (! (prefix(NS)+rosActionClient.actclient.name).equals(inConnection)){
+				if(HasNS){
+					return "<remap from='"+rosActionClient.actclient.name+"' to='/"+inConnection+"' />"
+				} else {
+					return "<remap from='"+rosActionClient.actclient.name+"' to='"+inConnection+"' />"
+				}
+		}} else if (!((prefix(NS)+rosActionClient.name).equals(compile_action_name(rosActionClient.actclient, NS)))){
+				return "<remap from='"+rosActionClient.actclient.name+"' to='"+rosActionClient.name+"' />";
+		}
+	}
+	def String inActionFromConnection(RosActionServer service, EList<ActionConnection> list) {
+		for (actionConnection:list){
+			if (actionConnection.from.equals(service)){
+				return actionConnection.actionName
+			}
+		}
+		return null ;
+	}
+	def String inActionToConnection(RosActionClient client, EList<ActionConnection> list) {
+		for (actionConnection:list){
+			if (actionConnection.to.equals(client)){
+				return actionConnection.actionName
+			}
+		}
+		return null ;
+	}
+	//
 
 	def check_ns(ComponentInterface component){
 		if (component.hasNS){

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
@@ -41,12 +41,12 @@ class LaunchFileCompiler_ROS1 {
   	<rosparam>
 		  «IF ROSParameter.value!==null»
 			  «FOR ParamMember:ROSParameter.value.eContents»
-			«getParamName(ParamMember.eContents.get(0))»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
+			«getParamName(ParamMember.eContents.get(0))»: «compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
 			  «ENDFOR»
 		  «ELSE»
 			  «FOR ParamMember:ROSParameter.eContents.get(0).eContents»
 				  «IF !(ParamMember.eContents.get(0).eContents.empty)»
-				«getParamName(ParamMember)»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
+				«getParamName(ParamMember)»: «compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
 				  «ENDIF»
 			  «ENDFOR»
 		  «ENDIF»

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
@@ -7,6 +7,7 @@ import java.util.List
 import org.eclipse.emf.ecore.EObject
 import ros.ParameterValue
 import rossystem.RosSystem
+import ros.impl.ParameterStructMemberImpl
 
 class LaunchFileCompiler_ROS1 {
 	@Inject extension GeneratorHelpers
@@ -30,12 +31,12 @@ class LaunchFileCompiler_ROS1 {
   	<rosparam>
 		  «IF ROSParameter.value!==null»
 			  «FOR ParamMember:ROSParameter.value.eContents»
-			«getParamName(ParamMember.eContents.get(0).toString)»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
+			«getParamName(ParamMember.eContents.get(0))»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
 			  «ENDFOR»
 		  «ELSE»
 			  «FOR ParamMember:ROSParameter.eContents.get(0).eContents»
 				  «IF !(ParamMember.eContents.get(0).eContents.empty)»
-				«getParamName(ParamMember.toString)»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
+				«getParamName(ParamMember)»:«compile_param_value(convertParamValue(ParamMember.eContents.get(0).eContents.get(0)))»
 				  «ENDIF»
 			  «ENDFOR»
 		  «ENDIF»
@@ -190,7 +191,7 @@ class LaunchFileCompiler_ROS1 {
 					for(i=1;i<sizes_list.size;i++){
 						tab_tmp+="  ";
 					}
-					str_output+=tab_tmp+getParamName(SubParamMember.toString)+": \n";
+					str_output+=tab_tmp+getParamName(SubParamMember)+": \n";
 					param_list.clear;
 					param_list.add(SubParamMember);
 					compile_struct_param(param_list,true);
@@ -258,8 +259,8 @@ class LaunchFileCompiler_ROS1 {
 		return component.nameSpace.replaceFirst("/","");
 	}
 
- 	def getParamName (String paramdef){
- 		return paramdef.substring(paramdef.indexOf("name:")+6,paramdef.indexOf(")"))
+ 	def getParamName (EObject paramdef){
+ 		return (paramdef as ParameterStructMemberImpl).name;
  	}
  	
 	def convertParamValue (Object ParamMember){

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS1.xtend
@@ -8,7 +8,7 @@ import org.eclipse.emf.ecore.EObject
 import ros.ParameterValue
 import rossystem.RosSystem
 
-class LaunchFileCompiler {
+class LaunchFileCompiler_ROS1 {
 	@Inject extension GeneratorHelpers
 	@Inject extension ComponentInterfaceCompiler
 
@@ -22,7 +22,7 @@ class LaunchFileCompiler {
 	int i=0;
 	int k=0;
 
-	def compile_tolaunch(RosSystem system) '''«init_comp()»
+	def compile_toROS1launch(RosSystem system) '''«init_comp()»
 <?xml version="1.0"?>
 <launch>
   «FOR ROSParameter:system.parameter»

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -1,0 +1,141 @@
+package de.fraunhofer.ipa.rossystem.generator
+
+import com.google.inject.Inject
+import componentInterface.ComponentInterface
+import java.util.ArrayList
+import java.util.List
+import org.eclipse.emf.ecore.EObject
+import ros.ParameterValue
+import rossystem.RosSystem
+
+class LaunchFileCompiler_ROS2 {
+	@Inject extension GeneratorHelpers
+	@Inject extension ComponentInterfaceCompiler
+
+	List<String> ListInterfaceDef
+	ParameterValue ParamValue
+	String str_output=""
+	String tab_tmp=""	
+	List<Integer> sizes_list = new ArrayList<Integer>();
+	List<EObject> param_list = new ArrayList<EObject>();
+	
+	int i=0;
+	int k=0;
+
+	def compile_toROS2launch(RosSystem system) '''«init_comp()»
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+	ld = LaunchDescription()
+
+	«FOR component:system.rosComponent»
+	«component.name» = Node(
+		package="«component.compile_pkg»«init_pkg»",
+		executable="«component.compile_art»«init_comp()»"
+	)
+	«ENDFOR»
+
+	«FOR component:system.rosComponent»
+	ld.add_action(«component.name»)
+	«ENDFOR»
+
+	return ld
+	'''
+
+	def check_ns(ComponentInterface component){
+		if (component.hasNS){
+			return component.get_ns();
+		}else {
+			return "";
+		}
+	}
+
+	def String compile_struct_param(List<EObject> paramMembers,Boolean sub){
+		if (!sub){
+			sizes_list.add(paramMembers.size);
+		} 
+		for (paramMember: paramMembers ){
+			if (paramMember.eClass.name=='ParameterStruct'){
+				for (SubParamMember:paramMember.eContents){				
+					tab_tmp="  ";//rosparam has to start with a first indentation as offset - fix
+					for(i=1;i<sizes_list.size;i++){
+						tab_tmp+="  ";
+					}
+					str_output+=tab_tmp+getParamName(SubParamMember.toString)+": \n";
+					param_list.clear;
+					param_list.add(SubParamMember);
+					compile_struct_param(param_list,true);
+	    		}
+			} else {
+				// FOR LIST
+				if (paramMember.eContents.get(0).eClass.name=="ParameterSequence"){
+					if(paramMember.eContents.get(0).eContents.get(0).eClass.name!=="ParameterStruct"){
+						str_output=str_output.substring(0, str_output.length() - 1);
+						str_output+="[";
+						for (seq_member:paramMember.eContents.get(0).eContents){
+							str_output+=compile_param_value(convertParamValue(seq_member))+",";
+						}
+						str_output = str_output.substring(0, str_output.length() - 1)+"]"+"\n";							
+					} else {
+						sizes_list.add(paramMember.eContents.get(0).eContents.size);
+						for (seq_member:paramMember.eContents.get(0).eContents){
+							param_list.clear;
+							param_list.add(seq_member);
+							compile_struct_param(param_list,true);
+							k=sizes_list.get(sizes_list.size-1);
+							k--;
+							sizes_list.remove(sizes_list.size() - 1);
+							if (k>0){
+								sizes_list.add(k);
+							}
+						}
+					}
+				//FOR PRIMITIVES: STRING, INT, ...
+				} else {
+					str_output=str_output.substring(0, str_output.length() - 1);
+					str_output+=compile_param_value(convertParamValue(paramMember.eContents.get(0)))+"\n";
+				}
+			}
+			if (!sub){
+				k=sizes_list.get(sizes_list.size-1);
+				k--;				
+				sizes_list.remove(sizes_list.size() - 1);
+				if (k>0){
+					sizes_list.add(k);
+				}
+			}
+		}
+		if (sizes_list.isEmpty){
+			return str_output.replace("null","");
+		}
+	}
+
+	def List<String> InterfaceDef(String name, String type){
+		ListInterfaceDef = new ArrayList()
+		ListInterfaceDef.add(name.replace("/","_"))
+		ListInterfaceDef.add(name)
+		ListInterfaceDef.add(type)
+		return ListInterfaceDef
+	}
+
+	def boolean hasNS(ComponentInterface component){
+		if(!component.nameSpace.nullOrEmpty){
+			return true;
+		}else{
+			return false
+		}
+	}
+	def String get_ns(ComponentInterface component){
+		return component.nameSpace.replaceFirst("/","");
+	}
+
+ 	def getParamName (String paramdef){
+ 		return paramdef.substring(paramdef.indexOf("name:")+6,paramdef.indexOf(")"))
+ 	}
+ 	
+	def convertParamValue (Object ParamMember){
+		ParamValue=ParamMember as ParameterValue
+		return ParamValue
+	}
+}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -5,12 +5,23 @@ import componentInterface.ComponentInterface
 import java.util.ArrayList
 import java.util.List
 import rossystem.RosSystem
+import org.eclipse.emf.common.util.EList
+import componentInterface.RosParameter
+import ros.ParameterValue
+import ros.impl.ParameterStringImpl
+import ros.impl.ParameterIntegerImpl
+import ros.impl.ParameterDoubleImpl
+import ros.impl.ParameterBooleanImpl
+import ros.impl.ParameterSequenceImpl
+import ros.impl.ParameterStructImpl
+import ros.impl.ParameterStructMemberImpl
 
 class LaunchFileCompiler_ROS2 {
 	@Inject extension GeneratorHelpers
 	@Inject extension ComponentInterfaceCompiler
 
 	List<String> ListInterfaceDef
+	int param_count
 
 	def compile_toROS2launch(RosSystem system) '''«init_comp()»
 from launch import LaunchDescription
@@ -24,7 +35,11 @@ def generate_launch_description():
 		package="«component.compile_pkg»«init_pkg»",
 		executable="«component.compile_art»«init_comp()»",
 		name="«component.name»"«IF component.hasNS»,
-		namespace="«component.get_ns»"«ENDIF»
+		namespace="«component.get_ns»"«ENDIF»«IF !component.rosparameter.empty»,
+		parameters=[
+			«component.rosparameter.compile_parameters_str»
+		]
+		«ENDIF»
 	)
 	«ENDFOR»
 
@@ -62,4 +77,47 @@ def generate_launch_description():
 		return component.nameSpace.replaceFirst("/","");
 	}
 
+	def String compile_parameters_str(EList<RosParameter> rosParameters) {
+		param_count = rosParameters.length;
+		var param_str = "";
+		for (rosParameter : rosParameters) {
+			val param_count=param_count--;
+			param_str += "{ \"" + rosParameter.parameter.name + "\" : " + get_param_value(rosParameter.value);
+			param_str += (param_count > 1) ? "},\n" : "}\n";
+		}
+		return param_str;
+	}
+
+	def String get_param_value(ParameterValue value) {
+		var param_val = "";
+		if (value instanceof ParameterStringImpl) {
+			param_val = "\"" + (value as ParameterStringImpl).getValue() + "\"";
+		} else if (value instanceof ParameterIntegerImpl) {
+			param_val = (value as ParameterIntegerImpl).getValue().toString;
+		} else if (value instanceof ParameterDoubleImpl) {
+			param_val = (value as ParameterDoubleImpl).getValue().toString;
+		} else if (value instanceof ParameterBooleanImpl) {
+			param_val = (value as ParameterBooleanImpl).isValue().toString;
+		} else if (value instanceof ParameterSequenceImpl) {
+			param_val += "[";
+			var elem_count = (value as ParameterSequenceImpl).eContents.length;
+			for (elem : (value as ParameterSequenceImpl).eContents) {
+				param_val += get_param_value(elem as ParameterValue);
+				elem_count--;
+				param_val += (elem_count > 0) ? ", " : "";
+			}
+			param_val += "]";
+		} else if (value instanceof ParameterStructImpl) {
+			var elem_count = (value as ParameterStructImpl).eContents.length;
+			param_val = "\n\t{ ";
+			for (elem : ((value as ParameterStructImpl).eContents)) {
+				var member = (elem as ParameterStructMemberImpl);
+				param_val += "\"" + member.getName() + "\" : " + get_param_value(member.getValue());
+				elem_count--;
+				param_val += (elem_count > 0) ? ",\n" : "";
+			}
+			param_val += " }";
+		}
+		return param_val;
+	 }
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -39,8 +39,7 @@ def generate_launch_description():
 		namespace="«component.get_ns»"«ENDIF»«IF !component.rosparameter.empty»,
 		parameters=[
 			«component.rosparameter.compile_parameters_str»
-		]«ENDIF»
-		«component.compile_remappings_str»
+		]«ENDIF»«component.compile_remappings_str»
 	)
 	«ENDFOR»
 
@@ -78,63 +77,41 @@ def generate_launch_description():
 		return component.nameSpace.replaceFirst("/","");
 	}
 
-	def String is_comma(Integer count) {
-		return (count > 0) ? ",\n" : "\n"
-	}
-
 	def String compile_remappings_str(ComponentInterface component) {
 		var remap_str = "";
-		var count = component.rospublisher.length
-					+ component.rossubscriber.length
-					+ component.rosserviceserver.length
-					+ component.rosserviceclient.length
-					+ component.rosactionserver.length
-					+ component.rosactionclient.length;
 		val NS = component.check_ns();
 		for (rosPublisher : component.rospublisher) {
 			if (!((prefix(NS)+rosPublisher.name).equals(compile_topic_name(rosPublisher.publisher, NS)))) {
-				remap_str += "\t(\"" + rosPublisher.publisher.name + "\", \"" + rosPublisher.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosPublisher.publisher.name + "\", \"" + rosPublisher.name + "\"),\n";
 			}
 		}
 		for (rosSubscriber : component.rossubscriber) {
 			if (!((prefix(NS)+rosSubscriber.name).equals(compile_topic_name(rosSubscriber.subscriber, NS)))) {
-				remap_str += "\t(\"" + rosSubscriber.subscriber.name + "\", \"" + rosSubscriber.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosSubscriber.subscriber.name + "\", \"" + rosSubscriber.name + "\"),\n";
 			}
 		}
 		for (rosServiceServer : component.rosserviceserver) {
 			if (!((prefix(NS)+rosServiceServer.name).equals(compile_service_name(rosServiceServer.srvserver, NS)))) {
-				remap_str += "\t(\"" + rosServiceServer.srvserver.name + "\", \"" + rosServiceServer.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosServiceServer.srvserver.name + "\", \"" + rosServiceServer.name + "\"),\n";
 			}
 		}
 		for (rosServiceClient : component.rosserviceclient) {
 			if (!((prefix(NS)+rosServiceClient.name).equals(compile_service_name(rosServiceClient.srvclient, NS)))) {
-				remap_str += "\t(\"" + rosServiceClient.srvclient.name + "\", \"" + rosServiceClient.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosServiceClient.srvclient.name + "\", \"" + rosServiceClient.name + "\"),\n";
 			}
 		}
 		for (rosActionServer : component.rosactionserver) {
 			if (!((prefix(NS)+rosActionServer.name).equals(compile_action_name(rosActionServer.actserver, NS)))) {
-				remap_str += "\t(\"" + rosActionServer.actserver.name + "\", \"" + rosActionServer.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosActionServer.actserver.name + "\", \"" + rosActionServer.name + "\"),\n";
 			}
 		}
 		for (rosActionClient : component.rosactionclient) {
 			if (!((prefix(NS)+rosActionClient.name).equals(compile_action_name(rosActionClient.actclient, NS)))) {
-				remap_str += "\t(\"" + rosActionClient.actclient.name + "\", \"" + rosActionClient.name + "\")";
-				count--;
-				remap_str += is_comma(count);
+				remap_str += "\t(\"" + rosActionClient.actclient.name + "\", \"" + rosActionClient.name + "\"),\n";
 			}
 		}
 		if (!remap_str.empty) {
-			remap_str = ",\nremappings=[\n" + remap_str + "]\n";
+			remap_str = ",\nremappings=[\n" + remap_str.substring(0,remap_str.length-2) + "]\n";
 		}
 		return remap_str;
 	}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -126,7 +126,11 @@ def generate_launch_description():
 			} else {
 				param_str += "{ \"" + rosParameter.parameter.name + "\" : " + get_param_value(rosParameter.value, rosParameter.parameter.name);
 			}
-			param_str += (param_count > 1) ? " },\n" : " }\n";
+			if (param_count > 1){ 
+				param_str +=" },\n"
+			} else {
+				param_str +=" }\n";
+			}
 		}
 		return param_str;
 	}
@@ -139,7 +143,9 @@ def generate_launch_description():
 			var member = ((elem as ParameterStructImpl).eContents.get(0) as ParameterStructMemberImpl);
 			param_str += "{ \"" + name + "/" + member.getName() + "\" : " + get_param_value(member.getValue(), member.getName());
 			elem_count--;
-			param_str += (elem_count > 0) ? " },\n" : "";
+			if (elem_count > 0){ 
+				param_str +=" },\n"
+			}
 		}
 
 		return param_str;
@@ -161,8 +167,10 @@ def generate_launch_description():
 			for (elem : (value as ParameterSequenceImpl).eContents) {
 				param_val += get_param_value(elem as ParameterValue, name);
 				elem_count--;
-				param_val += (elem_count > 0) ? ", " : "";
-			}
+				if (elem_count > 0){ 
+					param_val +=", "
+				}
+			} 
 			param_val += "]";
 		}
 		return param_val;

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -39,8 +39,8 @@ def generate_launch_description():
 		namespace="«component.get_ns»"«ENDIF»«IF !component.rosparameter.empty»,
 		parameters=[
 			«component.rosparameter.compile_parameters_str»
-		]
-		«ENDIF»
+		]«ENDIF»
+		«component.compile_remappings_str»
 	)
 	«ENDFOR»
 
@@ -76,6 +76,67 @@ def generate_launch_description():
 	}
 	def String get_ns(ComponentInterface component){
 		return component.nameSpace.replaceFirst("/","");
+	}
+
+	def String is_comma(Integer count) {
+		return (count > 0) ? ",\n" : "\n"
+	}
+
+	def String compile_remappings_str(ComponentInterface component) {
+		var remap_str = "";
+		var count = component.rospublisher.length
+					+ component.rossubscriber.length
+					+ component.rosserviceserver.length
+					+ component.rosserviceclient.length
+					+ component.rosactionserver.length
+					+ component.rosactionclient.length;
+		val NS = component.check_ns();
+		for (rosPublisher : component.rospublisher) {
+			if (!((prefix(NS)+rosPublisher.name).equals(compile_topic_name(rosPublisher.publisher, NS)))) {
+				remap_str += "\t(\"" + rosPublisher.publisher.name + "\", \"" + rosPublisher.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		for (rosSubscriber : component.rossubscriber) {
+			if (!((prefix(NS)+rosSubscriber.name).equals(compile_topic_name(rosSubscriber.subscriber, NS)))) {
+				remap_str += "\t(\"" + rosSubscriber.subscriber.name + "\", \"" + rosSubscriber.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		for (rosServiceServer : component.rosserviceserver) {
+			if (!((prefix(NS)+rosServiceServer.name).equals(compile_service_name(rosServiceServer.srvserver, NS)))) {
+				remap_str += "\t(\"" + rosServiceServer.srvserver.name + "\", \"" + rosServiceServer.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		for (rosServiceClient : component.rosserviceclient) {
+			if (!((prefix(NS)+rosServiceClient.name).equals(compile_service_name(rosServiceClient.srvclient, NS)))) {
+				remap_str += "\t(\"" + rosServiceClient.srvclient.name + "\", \"" + rosServiceClient.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		for (rosActionServer : component.rosactionserver) {
+			if (!((prefix(NS)+rosActionServer.name).equals(compile_action_name(rosActionServer.actserver, NS)))) {
+				remap_str += "\t(\"" + rosActionServer.actserver.name + "\", \"" + rosActionServer.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		for (rosActionClient : component.rosactionclient) {
+			if (!((prefix(NS)+rosActionClient.name).equals(compile_action_name(rosActionClient.actclient, NS)))) {
+				remap_str += "\t(\"" + rosActionClient.actclient.name + "\", \"" + rosActionClient.name + "\")";
+				count--;
+				remap_str += is_comma(count);
+			}
+		}
+		if (!remap_str.empty) {
+			remap_str = ",\nremappings=[\n" + remap_str + "]\n";
+		}
+		return remap_str;
 	}
 
 	def String compile_parameters_str(EList<RosParameter> rosParameters) {

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -32,7 +32,9 @@ def generate_launch_description():
 	«FOR component:system.rosComponent»
 	«component.name» = Node(
 		package="«component.compile_pkg»«init_pkg»",
-		executable="«component.compile_art»«init_comp()»"
+		executable="«component.compile_art»«init_comp()»",
+		name="«component.name»"«IF component.hasNS»,
+		namespace="«component.get_ns»"«ENDIF»
 	)
 	«ENDFOR»
 

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/LaunchFileCompiler_ROS2.xtend
@@ -4,8 +4,6 @@ import com.google.inject.Inject
 import componentInterface.ComponentInterface
 import java.util.ArrayList
 import java.util.List
-import org.eclipse.emf.ecore.EObject
-import ros.ParameterValue
 import rossystem.RosSystem
 
 class LaunchFileCompiler_ROS2 {
@@ -13,14 +11,6 @@ class LaunchFileCompiler_ROS2 {
 	@Inject extension ComponentInterfaceCompiler
 
 	List<String> ListInterfaceDef
-	ParameterValue ParamValue
-	String str_output=""
-	String tab_tmp=""	
-	List<Integer> sizes_list = new ArrayList<Integer>();
-	List<EObject> param_list = new ArrayList<EObject>();
-	
-	int i=0;
-	int k=0;
 
 	def compile_toROS2launch(RosSystem system) '''«init_comp()»
 from launch import LaunchDescription
@@ -53,66 +43,6 @@ def generate_launch_description():
 		}
 	}
 
-	def String compile_struct_param(List<EObject> paramMembers,Boolean sub){
-		if (!sub){
-			sizes_list.add(paramMembers.size);
-		} 
-		for (paramMember: paramMembers ){
-			if (paramMember.eClass.name=='ParameterStruct'){
-				for (SubParamMember:paramMember.eContents){				
-					tab_tmp="  ";//rosparam has to start with a first indentation as offset - fix
-					for(i=1;i<sizes_list.size;i++){
-						tab_tmp+="  ";
-					}
-					str_output+=tab_tmp+getParamName(SubParamMember.toString)+": \n";
-					param_list.clear;
-					param_list.add(SubParamMember);
-					compile_struct_param(param_list,true);
-	    		}
-			} else {
-				// FOR LIST
-				if (paramMember.eContents.get(0).eClass.name=="ParameterSequence"){
-					if(paramMember.eContents.get(0).eContents.get(0).eClass.name!=="ParameterStruct"){
-						str_output=str_output.substring(0, str_output.length() - 1);
-						str_output+="[";
-						for (seq_member:paramMember.eContents.get(0).eContents){
-							str_output+=compile_param_value(convertParamValue(seq_member))+",";
-						}
-						str_output = str_output.substring(0, str_output.length() - 1)+"]"+"\n";							
-					} else {
-						sizes_list.add(paramMember.eContents.get(0).eContents.size);
-						for (seq_member:paramMember.eContents.get(0).eContents){
-							param_list.clear;
-							param_list.add(seq_member);
-							compile_struct_param(param_list,true);
-							k=sizes_list.get(sizes_list.size-1);
-							k--;
-							sizes_list.remove(sizes_list.size() - 1);
-							if (k>0){
-								sizes_list.add(k);
-							}
-						}
-					}
-				//FOR PRIMITIVES: STRING, INT, ...
-				} else {
-					str_output=str_output.substring(0, str_output.length() - 1);
-					str_output+=compile_param_value(convertParamValue(paramMember.eContents.get(0)))+"\n";
-				}
-			}
-			if (!sub){
-				k=sizes_list.get(sizes_list.size-1);
-				k--;				
-				sizes_list.remove(sizes_list.size() - 1);
-				if (k>0){
-					sizes_list.add(k);
-				}
-			}
-		}
-		if (sizes_list.isEmpty){
-			return str_output.replace("null","");
-		}
-	}
-
 	def List<String> InterfaceDef(String name, String type){
 		ListInterfaceDef = new ArrayList()
 		ListInterfaceDef.add(name.replace("/","_"))
@@ -132,12 +62,4 @@ def generate_launch_description():
 		return component.nameSpace.replaceFirst("/","");
 	}
 
- 	def getParamName (String paramdef){
- 		return paramdef.substring(paramdef.indexOf("name:")+6,paramdef.indexOf(")"))
- 	}
- 	
-	def convertParamValue (Object ParamMember){
-		ParamValue=ParamMember as ParameterValue
-		return ParamValue
-	}
 }

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/PackageXmlCompiler.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/PackageXmlCompiler.xtend
@@ -8,7 +8,7 @@ class PackageXmlCompiler{
 	@Inject extension GeneratorHelpers
 	
 	
-		def compile_package_xml(RosSystem system) '''«init_pkg()»
+		def compile_package_xml_format2(RosSystem system) '''«init_pkg()»
 <package format="2">
   <name>«system.name.toLowerCase»</name>
   <version>0.0.1</version>
@@ -30,5 +30,39 @@ class PackageXmlCompiler{
   <!--test_depend>roslaunch</test_depend-->
 
 </package>'''
+
+		def compile_package_xml_format3(RosSystem system) '''«init_pkg()»
+<?xml version="1.0"?>
+<?xml-model
+   href="http://download.ros.org/schema/package_format3.xsd"
+   schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+ <name>«system.name.toLowerCase»</name>
+ <version>0.0.1</version>
+ <description>This package provides launch file for operating «system.name»</description>
+  <maintainer email="jane.doe@example.com">Jane Doe</maintainer>
+  <author email="jane.doe@example.com">Jane Doe</author>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  «FOR pkg:system.getPkgsDependencies»
+  <exec_depend>«pkg»</exec_depend>
+  «ENDFOR»
+
+  <!--test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>python3-pytest</test_depend-->
+
+  <export>
+  	<build_type>ament_python</build_type>
+  </export>
+</package>
+		'''
+
 
 		}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
@@ -72,13 +72,19 @@ class RosSystemGenerator extends AbstractGenerator {
 
 		//ROS2 package
 		for (system : resource.allContents.toIterable.filter(RosSystem)){
-				fsa.generateFile(system.getName().toLowerCase+"_ros2/launch/"+system.getName()+".launch",system.compile_toROS2launch.toString().replace("\t","  "))
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/launch/"+system.getName()+".launch.py",system.compile_toROS2launch.toString().replace("\t","  "))
 				}
 		for (system : resource.allContents.toIterable.filter(RosSystem)){
 				fsa.generateFile(system.getName().toLowerCase+"_ros2/package.xml",system.compile_package_xml_format3)
 				}
 		for (system : resource.allContents.toIterable.filter(RosSystem)){
 				fsa.generateFile(system.getName().toLowerCase+"_ros2/setup.py",system.compile_setup_py)
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/resource/" + system.getName().toLowerCase, "")
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/" + system.getName().toLowerCase + "/__init__.py", "")
 				}
 //		for (system : resource.allContents.toIterable.filter(RosSystem)){
 //				fsa.generateFile(system.getName().toLowerCase+"_ros2/CMakeLists.txt",system.compile_CMakeLists_ROS2)

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/RosSystemGenerator.xtend
@@ -43,27 +43,48 @@ class RosSystemGenerator extends AbstractGenerator {
 	@Inject extension PackageXmlCompiler
 	@Inject extension CMakeListsCompiler
 	@Inject extension ComponentInterfaceCompiler
-	@Inject extension LaunchFileCompiler
+	@Inject extension LaunchFileCompiler_ROS1
+	@Inject extension LaunchFileCompiler_ROS2
+	@Inject extension SetupPyCompile
+	
 	//@Inject extension InstallScriptCompiler
 	
 
 	override void doGenerate(Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {
-
-		for (system : resource.allContents.toIterable.filter(RosSystem)){
-				fsa.generateFile(system.getName().toLowerCase+"/launch/"+system.getName()+".launch",system.compile_tolaunch.toString().replace("\t","  "))
-				}
-		for (system : resource.allContents.toIterable.filter(RosSystem)){
-				fsa.generateFile(system.getName().toLowerCase+"/package.xml",system.compile_package_xml)
-				}
-		for (system : resource.allContents.toIterable.filter(RosSystem)){
-				fsa.generateFile(system.getName().toLowerCase+"/CMakeLists.txt",system.compile_CMakeLists)
-				}
 		for (system : resource.allContents.toIterable.filter(RosSystem)){
 				fsa.generateFile(system.getName()+".componentinterface",CustomOutputProvider::CM_CONFIGURATION,system.compile_toComponentInterface)
 				}
 //		for (system : resource.allContents.toIterable.filter(RosSystem)){
 //				fsa.generateFile(system.getName()+"install.sh",system.compile_toIntallScript)
 //				}
-			}
 
+
+		// ROS1 package
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"/launch/"+system.getName()+".launch",system.compile_toROS1launch.toString().replace("\t","  "))
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"/package.xml",system.compile_package_xml_format2)
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"/CMakeLists.txt",system.compile_CMakeLists_ROS1)
+				}
+
+		//ROS2 package
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/launch/"+system.getName()+".launch",system.compile_toROS2launch.toString().replace("\t","  "))
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/package.xml",system.compile_package_xml_format3)
+				}
+		for (system : resource.allContents.toIterable.filter(RosSystem)){
+				fsa.generateFile(system.getName().toLowerCase+"_ros2/setup.py",system.compile_setup_py)
+				}
+//		for (system : resource.allContents.toIterable.filter(RosSystem)){
+//				fsa.generateFile(system.getName().toLowerCase+"_ros2/CMakeLists.txt",system.compile_CMakeLists_ROS2)
+//				}
+
+
+	}
 }
+

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/SetupPyCompiler.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/SetupPyCompiler.xtend
@@ -1,0 +1,26 @@
+package de.fraunhofer.ipa.rossystem.generator
+
+import rossystem.RosSystem
+import com.google.inject.Inject
+
+class SetupPyCompile{
+	
+	@Inject extension GeneratorHelpers
+	
+	
+		def compile_setup_py(RosSystem system) '''«init_pkg()»
+from setuptools import setup
+
+PACKAGE_NAME = '«system.name.toLowerCase»'
+
+setup(
+    name=PACKAGE_NAME,
+    version='0.0.1',
+    packages=[PACKAGE_NAME],
+    data_files=[
+        ('share/' + PACKAGE_NAME + '/launch/*.launch.py')
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True
+)'''
+		}

--- a/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/SetupPyCompiler.xtend
+++ b/plugins/de.fraunhofer.ipa.rossystem.xtext/src/de/fraunhofer/ipa/rossystem/generator/SetupPyCompiler.xtend
@@ -9,6 +9,8 @@ class SetupPyCompile{
 	
 	
 		def compile_setup_py(RosSystem system) '''«init_pkg()»
+import os
+from glob import glob
 from setuptools import setup
 
 PACKAGE_NAME = '«system.name.toLowerCase»'
@@ -18,7 +20,13 @@ setup(
     version='0.0.1',
     packages=[PACKAGE_NAME],
     data_files=[
-        ('share/' + PACKAGE_NAME + '/launch/*.launch.py')
+        # Install marker file in the package index
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + PACKAGE_NAME]),
+        # Include our package.xml file
+        (os.path.join('share', PACKAGE_NAME), ['package.xml']),
+        # Include all launch files.
+        (os.path.join('share', PACKAGE_NAME, 'launch'), glob(os.path.join('launch', '*.launch.py')))
     ],
     install_requires=['setuptools'],
     zip_safe=True


### PR DESCRIPTION
This PR implements a first draft version of the launch file generator for ROS2. This version allows from the following model:

```
RosSystem { Name 'move_base_experiment' 
RosComponents ( 
    ComponentInterface { name base_driver  FromRosNode "ridgeback.base_driver.base_driver"
        RosPublishers{
            RosPublisher 'joint_states' { RefPublisher "ridgeback.base_driver.base_driver.joint_states"},
            RosPublisher odometry { RefPublisher "ridgeback.base_driver.base_driver.odometry"} , RosPublisher sondar_scan { RefPublisher "ridgeback.base_driver.base_driver.sondar_scan" } } RosSubscribers {
            RosSubscriber vel_command { RefSubscriber "ridgeback.base_driver.base_driver.cmd_vel"}}},
    ComponentInterface { name scan_driver FromRosNode "hokuyo_node.hokuyo_node.hokuyo_node"
        RosPublishers{
            RosPublisher 'scan' { RefPublisher 'hokuyo_node.hokuyo_node.hokuyo_node.scan'},
            RosPublisher 'diagnostics' { RefPublisher 'hokuyo_node.hokuyo_node.hokuyo_node.diagnostics'} , RosPublisher "hokuyo/parameter_descriptions" { RefPublisher "hokuyo_node.hokuyo_node.hokuyo_node.hokuyo/parameter_descriptions" } , RosPublisher "hokuyo/parameter_updates" { RefPublisher "hokuyo_node.hokuyo_node.hokuyo_node.hokuyo/parameter_updates" } } RosSrvClients { RosServiceClient "hokuyo/set_parameters" { RefClient "hokuyo_node.hokuyo_node.hokuyo_node.hokuyo/set_parameters" } , RosServiceClient "hokuyo/self_test" { RefClient "hokuyo_node.hokuyo_node.hokuyo_node.hokuyo/self_test" } } } , 
    ComponentInterface { name move_base FromRosNode "move_base.move_base.move_base" 
    	RosPublishers { 
    		RosPublisher cmd_vel { RefPublisher "move_base.move_base.move_base.cmd_vel" }}
    	RosSubscribers { 
    		RosSubscriber nav_goal { RefSubscriber "move_base.move_base.move_base.move_base/goal" }}} ,
    ComponentInterface { name  navigation FromRosNode "navigation.navigation.navigation"
    	RosPublishers { 
    		RosPublisher nav_goal { RefPublisher "navigation.navigation.navigation.move_base/goal" }}
    	RosSubscribers { 
    		RosSubscriber scan { RefSubscriber "navigation.navigation.navigation.scan" } , 
    		RosSubscriber odometry { RefSubscriber "navigation.navigation.navigation.odometry" } , 
    		 RosSubscriber joint_states { RefSubscriber "navigation.navigation.navigation.joint_states" } , 
    		RosSubscriber map { RefSubscriber "navigation.navigation.navigation.map" }
    	, RosSubscriber imu { RefSubscriber "navigation.navigation.navigation.imu" } } } )
    }} 
```
the auto-generation of the ROS package: https://github.com/ipa-nhg/test_ros2_code_extractor/tree/LaunchFileGenerator/move_base_experiment_ros2 
@ipa-hsd could you please check the generated code and let me know all the errors I introduced? 


Missed:
- [x] Remaps of interfaces
- [x] Definition of parameters
- [ ] Trigger of the ROS1 or ROS2 code generator. Currently both packages are generated always that the rossystem file is correct. From the point of view of the eclipse IDE we could create 2 different developer perspectives, one for ROS1 and other for ROS2 . But  I would like to evaluate how this can be done with the web interface (theia) before we change the implementation
- [ ] Extension of the rossystem model to support further ROS2 launch concepts. Depending on this extension I will consider to set at model level an attribute that specify the ROS version, this will simplify also the generation process
