### PR TITLE
Sugestion for a new grammar for the message specifications

### DIFF
--- a/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/Basics.xtext
+++ b/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/Basics.xtext
@@ -197,8 +197,7 @@ DateTime0 returns type::DateTime:
 //MESSAGE PRIMITIVES DEFINITION
 ///////////////////
 MessagePart returns primitives::MessagePart:
-    Type = AbstractType
-    Data =(KEYWORD | MESSAGE_ASIGMENT | EString)
+    Data =(KEYWORD | MESSAGE_ASIGMENT | EString)':' Type = AbstractType
 ;
 
 terminal MESSAGE_ASIGMENT:
@@ -288,66 +287,66 @@ duration returns primitives::duration:
 
 boolArray returns primitives::boolArray:
     {primitives::boolArray}
-    'bool[]'
+    '[bool]'
     ;
 
 int8Array returns primitives::int8Array:
     {primitives::int8Array}
-    'int8[]'
+    '[int8]'
     ;
 
 uint8Array returns primitives::uint8Array:
     {primitives::uint8Array}
-    'uint8[]'
+    '[uint8]'
     ;
 
 int16Array returns primitives::int16Array:
     {primitives::int16Array}
-    'int16[]'
+    '[int16]'
     ;
 
 uint16Array returns primitives::uint16Array:
     {primitives::uint16Array}
-    'uint16[]'
+    '[uint16]'
     ;
 
 int32Array returns primitives::int32Array:
     {primitives::int32Array}
-    'int32[]'
+    '[int32]'
     ;
 
 uint32Array returns primitives::uint32Array:
     {primitives::uint32Array}
-    'uint32[]'
+    '[uint32]'
     ;
 
 int64Array returns primitives::int64Array:
     {primitives::int64Array}
-    'int64[]'
+    '[int64]'
     ;
 
 uint64Array returns primitives::uint64Array:
     {primitives::uint64Array}
-    'uint64[]'
+    '[uint64]'
     ;
 
 float32Array returns primitives::float32Array:
     {primitives::float32Array}
-    'float32[]'
+    '[float32]'
     ;
 
 float64Array returns primitives::float64Array:
     {primitives::float64Array}
-    'float64[]'
+    '[float64]'
     ;
 
 string0Array returns primitives::stringArray:
     {primitives::stringArray}
-    'string[]'
+    '[string]'
     ;
 byteArray returns primitives::ByteArray:
     {primitives::ByteArray}
-    'byte[]'
+    '[byte]'
     ;
 
 Header returns primitives::Header:
@@ -360,7 +359,7 @@ TopicSpecRef returns TopicSpecRef:
 ;
 
 ArrayTopicSpecRef returns ArrayTopicSpecRef:
-    TopicSpec=[TopicSpec|EString]'[]'
+    '['TopicSpec=[TopicSpec|EString]']'
 ;
 
 KEYWORD: 'goal' | 'message' | 'result' | 'feedback' | 'name' | 'value' | 'service' | 'type' | 'action' | 'duration' | 'time'  ;
@@ -383,6 +382,9 @@ EString returns ecore::EString:
 RosNames returns ecore::EString:
     ROS_CONVENTION_A | ID | 'node'
 ;
+
+PreListElement hidden(SL_COMMENT):
+  '-';
 
 terminal ROS_CONVENTION_A:
     ( ('/' ID ) | ( ID '/' ) )* ;

--- a/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/Ros.xtext
+++ b/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/Ros.xtext
@@ -27,7 +27,8 @@ Package_Impl returns Package:
         ('fromGitRepo:' fromGitRepo=EString)?
         ('specs:'
             BEGIN
-            spec+=SpecBase*
+            PreListElement spec+=SpecBase
+            (PreListElement spec+=SpecBase)*
             END
         )?
         ('dependencies:' '[' dependency+=Dependency (',' dependency+=Dependency)* ']' )?
@@ -72,44 +73,43 @@ Artifact returns Artifact:
 
 Node returns Node:
     'node:' name=RosNames
-     BEGIN
-        (
-        ('publishers:'
-            BEGIN
-            publisher+=Publisher*
-            END
-        )|
-        ('subscribers:'
-            BEGIN
-            subscriber+=Subscriber*
-            END
-        )|
-        ('serviceservers:'
-            BEGIN
-            serviceserver+=ServiceServer*
-            END
-        )|
-        ('serviceclients:'
-            BEGIN
-            serviceclient+=ServiceClient*
-            END
-        )|
-        ('actionservers:'
-            BEGIN
-            actionserver+=ActionServer*
-            END
-        )|
-        ('actionclients:'
-            BEGIN
-            actionclient+=ActionClient*
-            END
-        )|
-        ('parameters:'
-            BEGIN
-            parameter+=Parameter*
-            END
-        )
-        )*END
+    (
+    ('publishers:'
+        BEGIN
+        publisher+=Publisher*
+        END
+    )|
+    ('subscribers:'
+        BEGIN
+        subscriber+=Subscriber*
+        END
+    )|
+    ('serviceServers:'
+        BEGIN
+        serviceserver+=ServiceServer*
+        END
+    )|
+    ('serviceClients:'
+        BEGIN
+        serviceclient+=ServiceClient*
+        END
+    )|
+    ('actionServers:'
+        BEGIN
+        actionserver+=ActionServer*
+        END
+    )|
+    ('actionClients:'
+        BEGIN
+        actionclient+=ActionClient*
+        END
+    )|
+    ('parameters:'
+        BEGIN
+        parameter+=Parameter*
+        END
+    )
+    )*
     ;
 
 ///////////////////
@@ -146,7 +146,7 @@ ActionSpec returns ActionSpec:
 
 MessageDefinition returns MessageDefinition:
     {MessageDefinition}
-        MessagePart+=MessagePart*;
+        MessagePart+=MessagePart+;
 
 ///////////////////
 //INTERFACES


### PR DESCRIPTION
These changes are from @ipa-rwu
This PR include the remaining commits from #194 
‼️ Code has to be re-generated before merge ‼️ 

This suggestion requires a major discussion. Initially, the idea was to keep the .msg format for the definition of the specifications, for example:

```
std_msgs:
 specs:
  msg: ColorRGBA
    message:
       float32 r
       float32 g
       float32 b
       float32 a
std_srvs:
 specs:
  srv: Trigger
    response:
       bool sucess
       string message
```

This approach will significantly lower the entry barrier for the ROS community. As the original code is:

std_msgs/ColorRGBA.msg

```
float32 r
float32 g
float32 b
float32 a
```

std_srvs/Trigger.srv

```
---
bool success   # indicate successful run of triggered service
string message # informational, e.g. for error messages
```

With this PR you are proposing:

```
std_msgs:
  specs:
    - msg: ColorRGBA
      message:
        r: float32
        g: float32
        b: float32
        a: float32
std_srvs:
  specs:
    - srv: Trigger
      request:
      response:
        success: bool
        "message": string
```