### PR TITLE
Give an exception to to capital letter in param names for plugin params

### DIFF
--- a/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/validation/RosValidator.xtend
+++ b/plugins/de.fraunhofer.ipa.ros.xtext/src/de/fraunhofer/ipa/ros/validation/RosValidator.xtend
@@ -50,12 +50,14 @@ class RosValidator extends AbstractRosValidator {
   }
    @Check
   def void checkNameConventionsParameters (Parameter parameter) {
-  	  if(!parameter.name.contains(".")) {
-		  for (char c : parameter.name.toCharArray) {
-		      if (Character.isUpperCase(c)){
-		          warning("The name of a parameter has to follow the ROS naming conventions: Capital letters are not recommended", null, INVALID_NAME);
-		      }
-		  }
+	  for (i : 0 ..< parameter.name.length) {
+	  	  val c = parameter.name.charAt(i)
+	      if (Character.isUpperCase(c)) {
+	      	  val remaining = parameter.name.substring(i)
+	      	  if (!remaining.contains(".")) {
+	          	warning("The name of a parameter has to follow the ROS naming conventions: Capital letters are not recommended", null, INVALID_NAME);	
+	          }
+	      }
 	  }
   }
 
@@ -141,4 +143,3 @@ class RosValidator extends AbstractRosValidator {
 //
 
 }
-


### PR DESCRIPTION
When params for plugins are specified, like the example below, the plugin names are included. These, at least in the case of nav2, have capital letters at times. This leads to an invalid triggering of the warning about naming conventions for params in ROS.

```
        "FollowPath.BaseObstacle.scale":
          type: Double
          value: 0.02
```

I also cleaned up the file in general while I was there.